### PR TITLE
JSLint (global and jslint declaration, single use strict closure to avoi...

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1,5 +1,5 @@
 /*globals $extend, $each, requestAnimationFrame*/
-/*jslint vars:true*/
+/*jslint vars:true, nomen: true, plusplus: true, white: true*/
 
 var JSONEditor = (function () {'use strict';
 


### PR DESCRIPTION
...d repeat or non-function "use strict" statements; curly braces, upper-case (and CamelCase) constructors per JS/JSLint convention; no need for else after previous if(s) return; define var out of loops; comment out unused function param, no assignments within statement; rmv need for continue (though jslint can be configured to allow))

The JSLint site gives rationales as to why it requires these things. If you are ok with it, I can go ahead and lint the other source files as well.

There's still an odd construction to me which I didn't correct because I didn't understand what you wanted it to do:

```
    if(arguments.length === 1) {
      return this.validator.validate(arguments[1]);
```

If `arguments.length` is only one, it should be `arguments[0]`, no? Otherwise, you are just passing `undefined`.
