### PR TITLE
Avoid "self" referring to "window"; adjust comment placement

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -4,14 +4,14 @@ JSONEditor.Validator = Class.extend({
     this.options = options || {};
     this.refs = this.options.refs || {};
 
-    // Store any $ref and definitions
     this.ready_callbacks = [];
 
     if(this.options.ready) this.ready(this.options.ready);
+    // Store any $ref and definitions
     this.getRefs();
   },
   ready: function(callback) {
-    if(this.is_ready) callback.apply(self,[this.expanded]);
+    if(this.is_ready) callback.apply(this,[this.expanded]);
     else {
       this.ready_callbacks.push(callback);
     }


### PR DESCRIPTION
Issue #130 wasn't actually resolved. The problem is that `self` is not defined as `this` in this particular function, so if you use the function (though you don't currently use it internally), it will treat `self` as the [global "self"](https://developer.mozilla.org/en-US/docs/Web/API/Window.self) which is a reference to the `window` object.
