### PR TITLE
skip afterInputReady for temporary string editor

### DIFF
--- a/src/editors/string.js
+++ b/src/editors/string.js
@@ -295,7 +295,10 @@ JSONEditor.defaults.editors.string = JSONEditor.AbstractEditor.extend({
 
     // Any special formatting that needs to happen after the input is added to the dom
     requestAnimationFrame(function() {
-      self.afterInputReady();
+      // Skip in case the input is only a temporary editor,
+      // otherwise, in the case of an ace_editor creation,
+      // it will generate an error trying to append it to the missing parentNode
+      if(self.input.parentNode) self.afterInputReady();
     });
     
     this.register();


### PR DESCRIPTION
checking the self.input.parentNode will avoid calling afterInputReady on temporary string editor inputs, otherwise if the input is an ACE code editor, it will try to add an element to the missing input parentNode causing an error
