### PR TITLE
Use proper "cssFloat" property for reserved word float (and CamelCase "m...

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -5,8 +5,8 @@ JSONEditor.AbstractTheme = Class.extend({
   getFloatRightLinkHolder: function() {
     var el = document.createElement('div');
     el.style = el.style || {};
-    el.style.float = 'right';
-    el.style['margin-left'] = '10px';
+    el.style.cssFloat = 'right';
+    el.style.marginLeft = '10px';
     return el;
   },
   getModal: function() {

--- a/src/themes/bootstrap3.js
+++ b/src/themes/bootstrap3.js
@@ -43,7 +43,7 @@ JSONEditor.defaults.themes.bootstrap3 = JSONEditor.AbstractTheme.extend({
       group.style.marginTop = '0';
       group.appendChild(label);
       input.style.position = 'relative';
-      input.style.float = 'left';
+      input.style.cssFloat = 'left';
     } 
     else {
       group.className += ' form-group';


### PR DESCRIPTION
...arginLeft")

This is untested (esp. since "getFloatRightLinkHolder" does not seem to be in use), but "float" must be escaped to "cssFloat" (at least to work in Firefox), and "margin-left" must be CamelCased.

Note that float will not work without a width.
