### PR TITLE
Added option to translate schema titles

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -341,7 +341,9 @@ JSONEditor.AbstractEditor = Class.extend({
     return null;
   },
   getTitle: function() {
-    return this.schema.title || this.key;
+    var title = this.schema.title || this.key;
+    if(this.jsoneditor.options.title_processing) return this.jsoneditor.options.title_processing(title);
+    else return title;
   },
   enable: function() {
     this.disabled = false;


### PR DESCRIPTION
Users can now translate schema titles by adding title_processing to their JSONEditor options.

Examle:
 JSONEditor.defaults.options = {
    templates: 'handlebars',
    theme: 'bootstrap3',
    title_processing: function(title){
      return I18n(title);
    }
  };
