### PR TITLE
[String customization] Never return undefined

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -26,7 +26,10 @@ JSONEditor.prototype = {
     this.root_container = this.theme.getContainer();
     this.element.appendChild(this.root_container);
     
-    this.translate = this.options.translate || JSONEditor.defaults.translate;
+    if(this.options.translate)
+      this.translate = function(key) {return self.options.translate(key) || JSONEditor.defaults.translate(key);};
+    else
+      this.translate = JSONEditor.defaults.translate;
 
     // Fetch all external refs via ajax
     this._loadExternalRefs(this.schema, function() {

--- a/src/core.js
+++ b/src/core.js
@@ -28,7 +28,7 @@ JSONEditor.prototype = {
     
     if(this.options.translate)
       this.translate = function(key, variables) {
-        var custom = self.options.translate(key);
+        var custom = self.options.translate(key, variables);
         return typeof custom === 'undefined' ? JSONEditor.defaults.translate(key, variables) : custom;
       };
     else

--- a/src/core.js
+++ b/src/core.js
@@ -27,7 +27,10 @@ JSONEditor.prototype = {
     this.element.appendChild(this.root_container);
     
     if(this.options.translate)
-      this.translate = function(key) {return self.options.translate(key) || JSONEditor.defaults.translate(key);};
+      this.translate = function(key, variables) {
+        var custom = self.options.translate(key);
+        return typeof custom === 'undefined' ? JSONEditor.defaults.translate(key, variables) : custom;
+      };
     else
       this.translate = JSONEditor.defaults.translate;
 


### PR DESCRIPTION
The default `translate` function will be used if a call to the custom one returns undefined.
This is a fallback to always display something, except if the custom returns an explicit empty string.

This is useful if you want to customize only a few translation keys without redefining it via JSON `JSONEditor.defaults.languages.*` for each language, which can be pretty annoying. And it allows better synergy with other translation mechanisms / libraries.
