### PR TITLE
Fixes disabled properties and fixes property order

### DIFF
--- a/src/editors/object.js
+++ b/src/editors/object.js
@@ -72,7 +72,7 @@ JSONEditor.defaults.editors.object = JSONEditor.AbstractEditor.extend({
     if(this.format === 'grid') {
       var rows = [];
       $each(this.property_order, function(i,key) {
-        editor = self.editors[key];
+        var editor = self.editors[key];
         if(editor.property_removed) return;
         var found = false;
         var width = editor.options.hidden? 0 : editor.getNumColumns();
@@ -155,7 +155,7 @@ JSONEditor.defaults.editors.object = JSONEditor.AbstractEditor.extend({
     else {
       container = document.createElement('div');
       $each(this.property_order, function(i,key) {
-        editor = self.editors[key];
+        var editor = self.editors[key];
         if(editor.property_removed) return;
         var row = self.theme.getGridRow();
         container.appendChild(row);


### PR DESCRIPTION
Option "no_additional_properties" is still behaving strange #209 —
allows initial properties to be re-added.

Maintain propertyOrder when using Object Properties #197
— uses already included property_order array
