### PR TITLE
add support for custom property sorters

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,6 +18,9 @@ module.exports = function(grunt) {
           // The main JSONEditor class
           'src/core.js',
 
+          // Sorters
+          'src/sorters.js',
+
           // JSON Schema validator
           'src/validator.js',
           

--- a/examples/advanced.html
+++ b/examples/advanced.html
@@ -58,7 +58,13 @@
       var editor = new JSONEditor(document.getElementById('editor_holder'),{
         // Enable fetching schemas via ajax
         ajax: true,
-        
+
+//        propertySorter: function (editors) {
+//          return Object.keys(editors).sort();
+//        },
+//        propertySorter: 'propertyOrder',
+//        propertySorter: 'native',
+
         // The schema for the editor
         schema: {
           type: "array",

--- a/src/core.js
+++ b/src/core.js
@@ -19,7 +19,9 @@ JSONEditor.prototype = {
     this.refs = this.options.refs || {};
     this.uuid = 0;
     this.__data = {};
-    
+
+    this.propertySorter = this.getPropertySorter();
+
     var icon_class = JSONEditor.defaults.iconlibs[this.options.iconlib || JSONEditor.defaults.iconlib];
     if(icon_class) this.iconlib = new icon_class();
 
@@ -162,6 +164,22 @@ JSONEditor.prototype = {
   createEditor: function(editor_class, options) {
     options = $extend({},editor_class.options||{},options);
     return new editor_class(options);
+  },
+  getPropertySorter: function () {
+    var propertySorter;
+    var propertySorterOption = this.options.propertySorter;
+    if (typeof propertySorterOption === 'function') {
+      propertySorter = propertySorterOption;
+    }
+    else if (typeof propertySorterOption === 'string') {
+      propertySorter = JSONEditor.defaults.propertySorters[propertySorterOption];
+      if (! propertySorter) throw "Unknown property sorter " + propertySorter;
+    }
+    else {
+      // Default to sort editors by propertyOrder
+      propertySorter = JSONEditor.defaults.propertySorters.propertyOrder;
+    }
+    return propertySorter;
   },
   onChange: function() {
     if(!this.ready) return;
@@ -540,6 +558,7 @@ JSONEditor.defaults = {
   templates: {},
   iconlibs: {},
   editors: {},
+  propertySorters: {},
   languages: {},
   resolvers: [],
   custom_validators: []

--- a/src/editors/object.js
+++ b/src/editors/object.js
@@ -56,17 +56,8 @@ JSONEditor.defaults.editors.object = JSONEditor.AbstractEditor.extend({
     
     if(!this.row_container) return;
 
-    // Sort editors by propertyOrder
-    this.property_order = Object.keys(this.editors);
-    this.property_order = this.property_order.sort(function(a,b) {
-      var ordera = self.editors[a].schema.propertyOrder;
-      var orderb = self.editors[b].schema.propertyOrder;
-      if(typeof ordera !== "number") ordera = 1000;
-      if(typeof orderb !== "number") orderb = 1000;
+    this.property_order = self.jsoneditor.propertySorter(this.editors);
 
-      return ordera - orderb;
-    });
-    
     var container;
     
     if(this.format === 'grid') {
@@ -244,17 +235,8 @@ JSONEditor.defaults.editors.object = JSONEditor.AbstractEditor.extend({
         }
       });
     }
-    
-    // Sort editors by propertyOrder
-    this.property_order = Object.keys(this.editors);
-    this.property_order = this.property_order.sort(function(a,b) {
-      var ordera = self.editors[a].schema.propertyOrder;
-      var orderb = self.editors[b].schema.propertyOrder;
-      if(typeof ordera !== "number") ordera = 1000;
-      if(typeof orderb !== "number") orderb = 1000;
 
-      return ordera - orderb;
-    });
+    this.property_order = self.jsoneditor.propertySorter(this.editors);
   },
   build: function() {
     var self = this;

--- a/src/sorters.js
+++ b/src/sorters.js
@@ -1,0 +1,16 @@
+JSONEditor.defaults.propertySorters.propertyOrder = function (editors) {
+  var property_order = Object.keys(editors);
+  return property_order.sort(function (a, b) {
+    var ordera = editors[a].schema.propertyOrder;
+    var orderb = editors[b].schema.propertyOrder;
+    if (typeof ordera !== "number") ordera = 1000;
+    if (typeof orderb !== "number") orderb = 1000;
+
+    return ordera - orderb;
+  });
+};
+
+JSONEditor.defaults.propertySorters.native = function (editors) {
+  var property_order = Object.keys(editors);
+  return property_order.sort();
+};


### PR DESCRIPTION
Leaves the default property sorter to respect `propertyOrder` on schema items. Allows override with custom `propertySorter` option as custom function or as string mapping to a `JSONEditor.defaults.propertySorters` implementation.
