### PR TITLE
removed setValue from switcher for oneOf, setValue was messing things up...

### DIFF
--- a/src/editors/multiple.js
+++ b/src/editors/multiple.js
@@ -54,12 +54,12 @@ JSONEditor.defaults.editors.multiple = JSONEditor.AbstractEditor.extend({
 
     self.register();
 
-    var current_value = self.getValue();
+    //var current_value = self.getValue();
 
     $each(self.editors,function(type,editor) {
       if(!editor) return;
       if(self.type === type) {
-        editor.setValue(current_value,true);
+        //editor.setValue(current_value,true);
         editor.container.style.display = '';
       }
       else editor.container.style.display = 'none';


### PR DESCRIPTION
removed setValue from switcher for oneOf, setValue was messing things up by adding fields from the current editor to the one being switched to. This may need a better solution later, maybe should be mapping fields if matches can be found, but throwing out ones that don't match