### PR TITLE
Prevent resolving to multiselect editor then enum_titles are specified

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -236,7 +236,7 @@ JSONEditor.defaults.resolvers.unshift(function(schema) {
 });
 // Use the 'multiselect' editor for arrays of enumerated strings/numbers/integers
 JSONEditor.defaults.resolvers.unshift(function(schema) {
-  if(schema.type === "array" && schema.items && !(Array.isArray(schema.items)) && schema.uniqueItems && schema.items.enum && ['string','number','integer'].indexOf(schema.items.type) >= 0) {
+  if(schema.type === "array" && schema.items && !(Array.isArray(schema.items)) && schema.uniqueItems && schema.items.enum && ['string','number','integer'].indexOf(schema.items.type) >= 0 && (!schema.items.options || !schema.items.options.enum_titles)) {
     return 'multiselect';
   }
 });


### PR DESCRIPTION
Default multiselect editor does not support `enum_titles`. He just doing this:

    this.select_values[e[i]+""] = e[i];

By preventing resolving to him it resolves to select which has `enum_titles` support.