### PR TITLE
Add support for labels in multiselects (options, associated to checkboxes  and select).

### DIFF
--- a/src/editors/multiselect.js
+++ b/src/editors/multiselect.js
@@ -4,17 +4,25 @@ JSONEditor.defaults.editors.multiselect = JSONEditor.AbstractEditor.extend({
 
     this.select_options = {};
     this.select_values = {};
+    this.select_titles = {};
 
     var items_schema = this.jsoneditor.expandRefs(this.schema.items || {});
 
     var e = items_schema.enum || [];
+    var option_titles = [];
+    if (items_schema.options) 
+	option_titles = items_schema.options.enum_titles || [];
+
     this.option_keys = [];
     for(i=0; i<e.length; i++) {
       // If the sanitized value is different from the enum value, don't include it
       if(this.sanitize(e[i]) !== e[i]) continue;
 
       this.option_keys.push(e[i]+"");
+
       this.select_values[e[i]+""] = e[i];
+      if (option_titles)
+      	this.select_titles[e[i]+""] = option_titles[i];
     }
   },
   build: function() {
@@ -29,8 +37,9 @@ JSONEditor.defaults.editors.multiselect = JSONEditor.AbstractEditor.extend({
       this.controls = {};
       for(i=0; i<this.option_keys.length; i++) {
         this.inputs[this.option_keys[i]] = this.theme.getCheckbox();
+	console.log( this.inputs[this.option_keys[i]]);
         this.select_options[this.option_keys[i]] = this.inputs[this.option_keys[i]];
-        var label = this.theme.getCheckboxLabel(this.option_keys[i]);
+        var label = this.theme.getCheckboxLabel(this.select_titles[this.option_keys[i]] || this.option_keys[i]);
         this.controls[this.option_keys[i]] = this.theme.getFormControl(label, this.inputs[this.option_keys[i]]);
       }
 
@@ -44,6 +53,10 @@ JSONEditor.defaults.editors.multiselect = JSONEditor.AbstractEditor.extend({
 
       for(i=0; i<this.option_keys.length; i++) {
         this.select_options[this.option_keys[i]] = this.input.children[i];
+	var label = this.select_titles[this.option_keys[i]];
+	if (label){
+	  this.input.children[i].text = label;
+	}
       }
 
       if(this.schema.readOnly || this.schema.readonly) {


### PR DESCRIPTION
here is the sample 

{
		   "schema":{
		      "properties":{
			 "property1":{
				     "items":{
					"type":"string",
					"enum":[
					   "value1",
					   "value2"
					],
					"options":{
					   "enum_titles":[
					      "Nice Label 1",
					      "Nice Label 2"
					   ]
					}
				     },
				     "uniqueItems":true,
				     "type":"array",
				     "format":"select"
			 },
				  "property2":{
				     "type":"string",
				     "enum":[
					"value1",
					"value2"
				     ],
				     "options":{
					"enum_titles":[
					   "Nice Label 1",
					   "Nice Label 2"
					]
				     }
				  }
			       },
		      "type":"object"
		   }
		};