### PR TITLE
Fix move down button of array editor being show even on the last element

### DIFF
--- a/src/editors/array.js
+++ b/src/editors/array.js
@@ -361,7 +361,7 @@ JSONEditor.defaults.editors.array = JSONEditor.AbstractEditor.extend({
       
       $each(this.rows,function(i,editor) {
         // Hide the move down button for the last row
-        if(editor.movedown_buttons) {
+        if(editor.movedown_button) {
           if(i === self.rows.length - 1) {
             editor.movedown_button.style.display = 'none';
           }


### PR DESCRIPTION
Hello,

currently there is a small typo, which causes the move down button to be shown on the last element of an array. This PR fixes this :smile:

Regards,
Benjamin