### PR TITLE
Fixed $ref handling in schema editing

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -328,7 +328,7 @@ JSONEditor.prototype = {
       }
     };
     
-    if(schema.$ref && schema.$ref.substr(0,1) !== "#" && !this.refs[schema.$ref]) {
+    if(schema.$ref && typeof schema.$ref !== "object" && schema.$ref.substr(0,1) !== "#" && !this.refs[schema.$ref]) {
       refs[schema.$ref] = true;
     }
     


### PR DESCRIPTION
Hi,

This PR contains a fix to be able to handle $ref properties while editing  json schema.

Example of schema that works now:
``` 
{
      "id": "http://some.site.somewhere/entry-schema#",
      "$schema": "http://json-schema.org/draft-04/schema#",
      "description": "schema for an $ref entry",
      "type": "object",
      "properties": {
         "$ref": {
            "type": "string"
          }
       }
    }
```
Cheers,
Hans