### PR TITLE
Added option to override change event

### DIFF
--- a/src/editors/string.js
+++ b/src/editors/string.js
@@ -188,8 +188,12 @@ JSONEditor.defaults.editors.string = JSONEditor.AbstractEditor.extend({
       this.input.disabled = true;
     }
 
+    var inputEvent = 'change';
+	// Check attribute overrideInputEvent to see if event 'change' should be overridden. I.e you could use 'keyup' to validate while the user is typing the string. Recommend to add _.debounce.
+    if(typeof this.schema.overrideInputEvent !== "undefined") inputEvent = this.schema.overrideInputEvent;
+
     this.input
-      .addEventListener('change',function(e) {        
+      .addEventListener(inputEvent ,function(e) {
         e.preventDefault();
         e.stopPropagation();
         


### PR DESCRIPTION
Sometimes  we need onChange on other events than 'change'. For example 'keyup'. This is useful when you want to validate while the user is typing the text. In this proposal you only have to add a "overrideInputEvent": "keyup" attribute to the field you want to give other input event than change.