### PR TITLE
Type check element argument

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1,4 +1,7 @@
 var JSONEditor = function(element,options) {
+  if (!(element instanceof Element)) {
+    throw new Error('element should be an instance of Element');
+  }
   options = $extend({},JSONEditor.defaults.options,options||{});
   this.element = element;
   this.options = options;


### PR DESCRIPTION
This took me a long time to figure out why it's not working. This should help in cases like that.
If element argument is not an instance of `Element` the program should fail fast and acknowledge the user.