### PR TITLE
Add type="button" attribute to avoid <button> elements being treated as submit controls

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -196,6 +196,7 @@ JSONEditor.AbstractTheme = Class.extend({
   },
   getButton: function(text, icon, title) {
     var el = document.createElement('button');
+    el.type = 'button';
     this.setButtonText(el,text,icon,title);
     return el;
   },


### PR DESCRIPTION
When `<button>` elements are nested inside `<form>` tags, the browser's default behavior is to treat them as `<button type="submit">`. 

This causes enter key press on any form element to trigger the click event on the first button of the form, typically the top-level collapse/expand button, as described in e.g. https://github.com/jdorn/json-editor/issues/273

This is not the expected behavior. The problem is solved by giving the button element attribute `type="button"` 

Fixes https://github.com/jdorn/json-editor/issues/273

