### PR TITLE
Adds Selectize support for array and select editors

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -38,10 +38,12 @@ module.exports = function(grunt) {
             'src/editors/multiple.js',
             'src/editors/enum.js',
             'src/editors/select.js',
+            'src/editors/selectize.js',
             'src/editors/multiselect.js',
             'src/editors/base64.js',
             'src/editors/upload.js',
             'src/editors/checkbox.js',
+            'src/editors/array/selectize.js',
 
             // All the themes and iconlibs
             'src/theme.js',

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The following are not required, but can improve the style and usability of JSON 
 *  [EpicEditor](http://epiceditor.com/) for editing of Markdown content
 *  [Ace Editor](http://ace.c9.io/) for editing code
 *  [Select2](http://ivaynberg.github.io/select2/) for nicer Select boxes
+*  [Selectize](http://brianreavis.github.io/selectize.js/) for nicer Select & Array boxes
 
 Usage
 --------------
@@ -1144,6 +1145,15 @@ The possibilities are endless.  Some ideas:
 *  Better editor for arrays of strings (tag editor)
 *  Canvas based image editor that produces Base64 data URLs
 
+Select2 & Selectize Support
+----------------
+Select2 support is enabled by default and will become active if the Select2 library is detected.
+
+Selectize support is enabled via the following snippet:
+```js
+JSONEditor.plugins.selectize.enable = true;
+```
+See the demo for an example of the `array` and `select` editor with Selectize support enabled.
 
 Custom Validation
 ----------------

--- a/demo.html
+++ b/demo.html
@@ -7,12 +7,10 @@
     <!-- placeholders for the theme switcher -->
     <link rel='stylesheet' id='theme_stylesheet'>
     <link rel='stylesheet' id='icon_stylesheet'>
+    <link rel='stylesheet' id='selectize_stylesheet'>
 
     <style>[class*="foundicon-"] {font-family: GeneralFoundicons;font-style: normal;}</style>
     <script src='dist/jsoneditor.js'></script>
-    <script src="dist/selectize-0.11.2-min.js"></script>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/selectize.js/0.12.1/js/standalone/selectize.js"></script>
-    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/selectize.js/0.12.1/css/selectize.bootstrap3.css">
 
     <script>
     /**
@@ -86,9 +84,7 @@
                     </select>
                 </div>
                 <div>
-                    <label>
-                        <input id='selectize_support' type='checkbox'> Selectize Support
-                    </label>
+                    <button class='btn btn-primary' id='selectize_support'>Enable Selectize Support</button>
                 </div>
                 <div>
                     <label>Boolean options</label>
@@ -395,6 +391,14 @@ editor.on("change",  function() {
         if(!no_reload) reload(true);
     };
 
+    function loadScript(path, onload) {
+        var script = document.createElement('script');
+        script.type = 'text/javascript';
+        script.src = path;
+        script.onload = onload
+        document.getElementsByTagName('head')[0].appendChild(script);
+    }
+
     // Change listeners for options
     document.getElementById('theme_switcher').addEventListener('change',function() {
         setTheme(this.value);
@@ -410,9 +414,22 @@ editor.on("change",  function() {
        JSONEditor.defaults.options.show_errors = this.value;
         reload(true);
     });
-    document.getElementById('selectize_support').addEventListener('change',function() {
-        JSONEditor.plugins.selectize.enable = (this.value === 'on');
-        reload(true);
+    document.getElementById('selectize_support').addEventListener('click',function() {
+        var button = this;
+
+        JSONEditor.plugins.selectize.enable = true;
+
+        if (!window.jQuery) {
+            document.getElementById('selectize_stylesheet').href = '//cdnjs.cloudflare.com/ajax/libs/selectize.js/0.12.1/css/selectize.bootstrap3.css';
+
+            // jQuery must be loaded before Selectize can be safely loaded
+            loadScript('//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js', function() {
+                loadScript('//cdnjs.cloudflare.com/ajax/libs/selectize.js/0.12.1/js/standalone/selectize.js', function() {
+                    button.setAttribute('disabled', true)
+                    reload(true);
+                })
+            });
+        }
     });
     document.getElementById('boolean_options').addEventListener('change',function() {
         refreshBooleanOptions();

--- a/demo.html
+++ b/demo.html
@@ -10,7 +10,10 @@
 
     <style>[class*="foundicon-"] {font-family: GeneralFoundicons;font-style: normal;}</style>
     <script src='dist/jsoneditor.js'></script>
-    
+    <script src="dist/selectize-0.11.2-min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/selectize.js/0.12.1/js/standalone/selectize.js"></script>
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/selectize.js/0.12.1/css/selectize.bootstrap3.css">
+
     <script>
     /**
      * LZString compression library
@@ -81,6 +84,11 @@
                         <option value='always'>Always</option>
                         <option value='never'>Never</option>
                     </select>
+                </div>
+                <div>
+                    <label>
+                        <input id='selectize_support' type='checkbox'> Selectize Support
+                    </label>
                 </div>
                 <div>
                     <label>Boolean options</label>
@@ -188,6 +196,13 @@ editor.on("change",  function() {
                 gender: {
                     type: "string",
                     enum: ["male", "female"]
+                },
+                interests: {
+                    type: "array",
+                    items: {
+                        type: "string"
+                    },
+                    default: ["Squash", "Badminton", "Rugby"]
                 },
                 location: {
                     type: "object",
@@ -393,6 +408,10 @@ editor.on("change",  function() {
     });
     document.getElementById('show_errors').addEventListener('change',function() {
        JSONEditor.defaults.options.show_errors = this.value;
+        reload(true);
+    });
+    document.getElementById('selectize_support').addEventListener('change',function() {
+        JSONEditor.plugins.selectize.enable = (this.value === 'on');
         reload(true);
     });
     document.getElementById('boolean_options').addEventListener('change',function() {

--- a/examples/selectize.html
+++ b/examples/selectize.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>JSON Editor Selectize Integration Example</title>
+    <script src="../dist/jsoneditor.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/selectize.js/0.12.1/js/standalone/selectize.js"></script>
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/selectize.js/0.12.1/css/selectize.bootstrap3.css">
+  </head>
+  <body>
+    <h1>JSON Editor Selectize Integration Example</h1>
+
+    <p style='margin-bottom:20px;'>This example demonstrates JSONEditor's integration with Selectize</p>
+
+    <div id='editor_holder'></div>
+    <button id='submit'>Submit (console.log)</button>
+
+    <script>
+    // Global selectize options
+    JSONEditor.plugins.selectize.enable = true;
+
+      // Initialize the editor with a JSON schema
+      var editor = new JSONEditor(document.getElementById('editor_holder'),{
+        schema: {
+          type: "object",
+          title: "Text",
+          required: ["fontSize","color","font","weight","possibleFonts"],
+          properties: {
+            fontSize: {
+              type: "integer",
+              enum: [10,11,12,14,16,18,20,22,24,36,48,60,72,100],
+              default: 24,
+            },
+            color: {
+              type: "string",
+              enum: ["black","red","green","blue","yellow","orange","purple","brown","white","cyan","maagenta"],
+              options: {
+                // Override defaullt options
+                selectize_options: {
+                  create: true,
+                  sortField: 'text'
+                }
+              }
+            },
+            font: {
+              type: "string",
+              enumSource: "possible_fonts",
+              watch: {
+                "possible_fonts": "root.possibleFonts"
+              },
+            },
+            weight: {
+              type: "string",
+              enum: ["normal","bold","bolder","lighter"],
+              options: {
+                enum_titles: ["Normal (400)","Bold (700)","Bolder (900)","Lighter (200)"]
+              }
+            },
+            possibleFonts: {
+              type: "array",
+              format: 'table',
+              items: {
+                type: "string"
+              },
+              default: ["Arial","Times","Helvetica","Comic Sans"],
+              options: {
+                collapsed: true
+              }
+            }
+          }
+        },
+        startval: {
+          color: "red"
+        }
+      });
+
+      // Hook up the submit button to log to the console
+      document.getElementById('submit').addEventListener('click',function() {
+        // Get the value from the editor
+        console.log(editor.getValue());
+      });
+    </script>
+  </body>
+</html>

--- a/src/core.js
+++ b/src/core.js
@@ -180,6 +180,9 @@ JSONEditor.prototype = {
     });
 
     if(!classname) throw "Unknown editor for schema "+JSON.stringify(schema);
+    if(classname === "array" && JSONEditor.plugins.selectize.enable) {
+        classname = classname + "Selectize";
+    }
     if(!JSONEditor.defaults.editors[classname]) throw "Unknown editor "+classname;
 
     return JSONEditor.defaults.editors[classname];

--- a/src/core.js
+++ b/src/core.js
@@ -180,9 +180,6 @@ JSONEditor.prototype = {
     });
 
     if(!classname) throw "Unknown editor for schema "+JSON.stringify(schema);
-    if(classname === "array" && JSONEditor.plugins.selectize.enable) {
-        classname = classname + "Selectize";
-    }
     if(!JSONEditor.defaults.editors[classname]) throw "Unknown editor "+classname;
 
     return JSONEditor.defaults.editors[classname];

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -169,6 +169,8 @@ JSONEditor.plugins = {
   },
   select2: {
     
+  },
+  selectize: {
   }
 };
 
@@ -196,7 +198,7 @@ JSONEditor.defaults.resolvers.unshift(function(schema) {
       return "checkbox";
     }
     // Otherwise, default to select menu
-    return "select";
+    return (JSONEditor.plugins.selectize.enable) ? 'selectize' : 'select';
   }
 });
 // Use the multiple editor for schemas where the `type` is set to "any"
@@ -226,7 +228,7 @@ JSONEditor.defaults.resolvers.unshift(function(schema) {
 });
 // Use the `select` editor for dynamic enumSource enums
 JSONEditor.defaults.resolvers.unshift(function(schema) {
-  if(schema.enumSource) return "select";
+  if(schema.enumSource) return (JSONEditor.plugins.selectize.enable) ? 'selectize' : 'select';
 });
 // Use the `enum` or `select` editors for schemas with enumerated properties
 JSONEditor.defaults.resolvers.unshift(function(schema) {
@@ -235,7 +237,7 @@ JSONEditor.defaults.resolvers.unshift(function(schema) {
       return "enum";
     }
     else if(schema.type === "number" || schema.type === "integer" || schema.type === "string") {
-      return "select";
+      return (JSONEditor.plugins.selectize.enable) ? 'selectize' : 'select';
     }
   }
 });

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -252,3 +252,9 @@ JSONEditor.defaults.resolvers.unshift(function(schema) {
   // If this schema uses `oneOf`
   if(schema.oneOf) return "multiple";
 });
+// If enabled, use Selectize for arrays
+JSONEditor.defaults.resolvers.unshift(function(schema) {
+  if(schema.type === "array" && JSONEditor.plugins.selectize.enable) {
+      return 'arraySelectize';
+  }
+});

--- a/src/editors/array/selectize.js
+++ b/src/editors/array/selectize.js
@@ -1,0 +1,99 @@
+JSONEditor.defaults.editors.arraySelectize = JSONEditor.AbstractEditor.extend({
+  build: function() {
+
+    var self = this;
+
+    this.title = this.theme.getFormInputLabel(this.getTitle());
+
+    this.title_controls = this.theme.getHeaderButtonHolder();
+    this.title.appendChild(this.title_controls);
+    this.error_holder = document.createElement('div');
+
+    if(this.schema.description) {
+      this.description = this.theme.getDescription(this.schema.description);
+    }
+
+    this.input = document.createElement('input');
+    this.input.setAttribute('type', 'text');
+
+    var group = this.theme.getFormControl(this.title, this.input, this.description);
+
+    this.container.appendChild(group);
+    this.container.appendChild(this.error_holder);
+
+    window.jQuery(this.input).selectize({
+      delimiter: ',',
+      createOnBlur: true,
+      create: true
+    });
+
+
+  },
+  postBuild: function() {
+      var self = this;
+      this.input.selectize.on('change', function(event) {
+          self.refreshValue();
+          self.onChange(true);
+      });
+  },
+  destroy: function() {
+    this.empty(true);
+    if(this.title && this.title.parentNode) this.title.parentNode.removeChild(this.title);
+    if(this.description && this.description.parentNode) this.description.parentNode.removeChild(this.description);
+    if(this.input && this.input.parentNode) this.input.parentNode.removeChild(this.input);
+
+    this._super();
+  },
+  empty: function(hard) {},
+  setValue: function(value, initial) {
+    var self = this;
+    // Update the array's value, adding/removing rows when necessary
+    value = value || [];
+    if(!(Array.isArray(value))) value = [value];
+
+    this.input.selectize.clearOptions();
+    this.input.selectize.clear(true);
+
+    value.forEach(function(item) {
+      self.input.selectize.addOption({text: item, value: item});
+    });
+    this.input.selectize.setValue(value);
+
+    this.refreshValue(initial);
+  },
+  refreshValue: function(force) {
+    this.value = this.input.value.split(',');
+  },
+  showValidationErrors: function(errors) {
+    var self = this;
+
+    // Get all the errors that pertain to this editor
+    var my_errors = [];
+    var other_errors = [];
+    $each(errors, function(i,error) {
+      if(error.path === self.path) {
+        my_errors.push(error);
+      }
+      else {
+        other_errors.push(error);
+      }
+    });
+
+    // Show errors for this editor
+    if(this.error_holder) {
+
+      if(my_errors.length) {
+        var message = [];
+        this.error_holder.innerHTML = '';
+        this.error_holder.style.display = '';
+        $each(my_errors, function(i,error) {
+          self.error_holder.appendChild(self.theme.getErrorMessage(error.message));
+        });
+      }
+      // Hide error area
+      else {
+        this.error_holder.style.display = 'none';
+      }
+    }
+  }
+});

--- a/src/editors/array/selectize.js
+++ b/src/editors/array/selectize.js
@@ -1,8 +1,5 @@
 JSONEditor.defaults.editors.arraySelectize = JSONEditor.AbstractEditor.extend({
   build: function() {
-
-    var self = this;
-
     this.title = this.theme.getFormInputLabel(this.getTitle());
 
     this.title_controls = this.theme.getHeaderButtonHolder();
@@ -13,8 +10,8 @@ JSONEditor.defaults.editors.arraySelectize = JSONEditor.AbstractEditor.extend({
       this.description = this.theme.getDescription(this.schema.description);
     }
 
-    this.input = document.createElement('input');
-    this.input.setAttribute('type', 'text');
+    this.input = document.createElement('select');
+    this.input.setAttribute('multiple', 'multiple');
 
     var group = this.theme.getFormControl(this.title, this.input, this.description);
 
@@ -22,12 +19,10 @@ JSONEditor.defaults.editors.arraySelectize = JSONEditor.AbstractEditor.extend({
     this.container.appendChild(this.error_holder);
 
     window.jQuery(this.input).selectize({
-      delimiter: ',',
+      delimiter: false,
       createOnBlur: true,
       create: true
     });
-
-
   },
   postBuild: function() {
       var self = this;
@@ -62,7 +57,7 @@ JSONEditor.defaults.editors.arraySelectize = JSONEditor.AbstractEditor.extend({
     this.refreshValue(initial);
   },
   refreshValue: function(force) {
-    this.value = this.input.value.split(',');
+    this.value = this.input.selectize.getValue();
   },
   showValidationErrors: function(errors) {
     var self = this;

--- a/src/editors/selectize.js
+++ b/src/editors/selectize.js
@@ -1,0 +1,346 @@
+JSONEditor.defaults.editors.selectize = JSONEditor.AbstractEditor.extend({
+  setValue: function(value,initial) {
+    value = this.typecast(value||'');
+
+    // Sanitize value before setting it
+    var sanitized = value;
+    if(this.enum_values.indexOf(sanitized) < 0) {
+      sanitized = this.enum_values[0];
+    }
+
+    if(this.value === sanitized) {
+      return;
+    }
+
+    this.input.value = this.enum_options[this.enum_values.indexOf(sanitized)];
+
+    if(this.selectize) {
+      this.selectize[0].selectize.addItem(sanitized);
+    }
+
+    this.value = sanitized;
+    this.onChange();
+  },
+  register: function() {
+    this._super();
+    if(!this.input) return;
+    this.input.setAttribute('name',this.formname);
+  },
+  unregister: function() {
+    this._super();
+    if(!this.input) return;
+    this.input.removeAttribute('name');
+  },
+  getNumColumns: function() {
+    if(!this.enum_options) return 3;
+    var longest_text = this.getTitle().length;
+    for(var i=0; i<this.enum_options.length; i++) {
+      longest_text = Math.max(longest_text,this.enum_options[i].length+4);
+    }
+    return Math.min(12,Math.max(longest_text/7,2));
+  },
+  typecast: function(value) {
+    if(this.schema.type === "boolean") {
+      return !!value;
+    }
+    else if(this.schema.type === "number") {
+      return 1*value;
+    }
+    else if(this.schema.type === "integer") {
+      return Math.floor(value*1);
+    }
+    else {
+      return ""+value;
+    }
+  },
+  getValue: function() {
+    return this.value;
+  },
+  preBuild: function() {
+    var self = this;
+    this.input_type = 'select';
+    this.enum_options = [];
+    this.enum_values = [];
+    this.enum_display = [];
+
+    // Enum options enumerated
+    if(this.schema.enum) {
+      var display = this.schema.options && this.schema.options.enum_titles || [];
+
+      $each(this.schema.enum,function(i,option) {
+        self.enum_options[i] = ""+option;
+        self.enum_display[i] = ""+(display[i] || option);
+        self.enum_values[i] = self.typecast(option);
+      });
+    }
+    // Boolean
+    else if(this.schema.type === "boolean") {
+      self.enum_display = this.schema.options && this.schema.options.enum_titles || ['true','false'];
+      self.enum_options = ['1','0'];
+      self.enum_values = [true,false];
+    }
+    // Dynamic Enum
+    else if(this.schema.enumSource) {
+      this.enumSource = [];
+      this.enum_display = [];
+      this.enum_options = [];
+      this.enum_values = [];
+
+      // Shortcut declaration for using a single array
+      if(!(Array.isArray(this.schema.enumSource))) {
+        if(this.schema.enumValue) {
+          this.enumSource = [
+            {
+              source: this.schema.enumSource,
+              value: this.schema.enumValue
+            }
+          ];
+        }
+        else {
+          this.enumSource = [
+            {
+              source: this.schema.enumSource
+            }
+          ];
+        }
+      }
+      else {
+        for(i=0; i<this.schema.enumSource.length; i++) {
+          // Shorthand for watched variable
+          if(typeof this.schema.enumSource[i] === "string") {
+            this.enumSource[i] = {
+              source: this.schema.enumSource[i]
+            };
+          }
+          // Make a copy of the schema
+          else if(!(Array.isArray(this.schema.enumSource[i]))) {
+            this.enumSource[i] = $extend({},this.schema.enumSource[i]);
+          }
+          else {
+            this.enumSource[i] = this.schema.enumSource[i];
+          }
+        }
+      }
+
+      // Now, enumSource is an array of sources
+      // Walk through this array and fix up the values
+      for(i=0; i<this.enumSource.length; i++) {
+        if(this.enumSource[i].value) {
+          this.enumSource[i].value = this.jsoneditor.compileTemplate(this.enumSource[i].value, this.template_engine);
+        }
+        if(this.enumSource[i].title) {
+          this.enumSource[i].title = this.jsoneditor.compileTemplate(this.enumSource[i].title, this.template_engine);
+        }
+        if(this.enumSource[i].filter) {
+          this.enumSource[i].filter = this.jsoneditor.compileTemplate(this.enumSource[i].filter, this.template_engine);
+        }
+      }
+    }
+    // Other, not supported
+    else {
+      throw "'select' editor requires the enum property to be set.";
+    }
+  },
+  build: function() {
+    var self = this;
+    if(!this.options.compact) this.header = this.label = this.theme.getFormInputLabel(this.getTitle());
+    if(this.schema.description) this.description = this.theme.getFormInputDescription(this.schema.description);
+
+    if(this.options.compact) this.container.className += ' compact';
+
+    this.input = this.theme.getSelectInput(this.enum_options);
+    this.theme.setSelectOptions(this.input,this.enum_options,this.enum_display);
+
+    if(this.schema.readOnly || this.schema.readonly) {
+      this.always_disabled = true;
+      this.input.disabled = true;
+    }
+
+    this.input.addEventListener('change',function(e) {
+      e.preventDefault();
+      e.stopPropagation();
+      self.onInputChange();
+    });
+
+    this.control = this.theme.getFormControl(this.label, this.input, this.description);
+    this.container.appendChild(this.control);
+
+    this.value = this.enum_values[0];
+  },
+  onInputChange: function() {
+    var val = this.input.value;
+
+    var sanitized = val;
+    if(this.enum_options.indexOf(val) === -1) {
+      sanitized = this.enum_options[0];
+    }
+
+    this.value = this.enum_values[this.enum_options.indexOf(val)];
+    this.onChange(true);
+  },
+  setupSelectize: function() {
+    // If the Selectize library is loaded use it when we have lots of items
+    var self = this;
+    if(window.jQuery && window.jQuery.fn && window.jQuery.fn.selectize && (this.enum_options.length >= 2 || (this.enum_options.length && this.enumSource))) {
+      var options = $extend({},JSONEditor.plugins.selectize);
+      if(this.schema.options && this.schema.options.selectize_options) options = $extend(options,this.schema.options.selectize_options);
+      this.selectize = window.jQuery(this.input).selectize($extend(options,
+      {
+        create: true,
+        onChange : function() {
+          self.onInputChange();
+        }
+      }));
+    }
+    else {
+      this.selectize = null;
+    }
+  },
+  postBuild: function() {
+    this._super();
+    this.theme.afterInputReady(this.input);
+    this.setupSelectize();
+  },
+  onWatchedFieldChange: function() {
+    var self = this, vars, j;
+
+    // If this editor uses a dynamic select box
+    if(this.enumSource) {
+      vars = this.getWatchedFieldValues();
+      var select_options = [];
+      var select_titles = [];
+
+      for(var i=0; i<this.enumSource.length; i++) {
+        // Constant values
+        if(Array.isArray(this.enumSource[i])) {
+          select_options = select_options.concat(this.enumSource[i]);
+          select_titles = select_titles.concat(this.enumSource[i]);
+        }
+        // A watched field
+        else if(vars[this.enumSource[i].source]) {
+          var items = vars[this.enumSource[i].source];
+
+          // Only use a predefined part of the array
+          if(this.enumSource[i].slice) {
+            items = Array.prototype.slice.apply(items,this.enumSource[i].slice);
+          }
+          // Filter the items
+          if(this.enumSource[i].filter) {
+            var new_items = [];
+            for(j=0; j<items.length; j++) {
+              if(this.enumSource[i].filter({i:j,item:items[j]})) new_items.push(items[j]);
+            }
+            items = new_items;
+          }
+
+          var item_titles = [];
+          var item_values = [];
+          for(j=0; j<items.length; j++) {
+            var item = items[j];
+
+            // Rendered value
+            if(this.enumSource[i].value) {
+              item_values[j] = this.enumSource[i].value({
+                i: j,
+                item: item
+              });
+            }
+            // Use value directly
+            else {
+              item_values[j] = items[j];
+            }
+
+            // Rendered title
+            if(this.enumSource[i].title) {
+              item_titles[j] = this.enumSource[i].title({
+                i: j,
+                item: item
+              });
+            }
+            // Use value as the title also
+            else {
+              item_titles[j] = item_values[j];
+            }
+          }
+
+          // TODO: sort
+
+          select_options = select_options.concat(item_values);
+          select_titles = select_titles.concat(item_titles);
+        }
+      }
+
+      var prev_value = this.value;
+
+      this.theme.setSelectOptions(this.input, select_options, select_titles);
+      this.enum_options = select_options;
+      this.enum_display = select_titles;
+      this.enum_values = select_options;
+
+      // If the previous value is still in the new select options, stick with it
+      if(select_options.indexOf(prev_value) !== -1) {
+        this.input.value = prev_value;
+        this.value = prev_value;
+      }
+
+      // Otherwise, set the value to the first select option
+      else {
+        this.input.value = select_options[0];
+        this.value = select_options[0] || "";
+        if(this.parent) this.parent.onChildEditorChange(this);
+        else this.jsoneditor.onChange();
+        this.jsoneditor.notifyWatchers(this.path);
+      }
+
+      if(this.selectize) {
+        // Update the Selectize options
+        this.updateSelectizeOptions(select_options);
+      }
+      else {
+        this.setupSelectize();
+      }
+
+      this._super();
+    }
+  },
+  updateSelectizeOptions: function(select_options) {
+    var selectized = this.selectize[0].selectize,
+        self = this;
+
+    selectized.off();
+    selectized.clearOptions();
+    for(var n in select_options) {
+      selectized.addOption({value:select_options[n],text:select_options[n]});
+    }
+    selectized.addItem(this.value);
+    selectized.on('change',function() {
+      self.onInputChange();
+    });
+  },
+  enable: function() {
+    if(!this.always_disabled) {
+      this.input.disabled = false;
+      if(this.selectize) {
+        this.selectize[0].selectize.unlock();
+      }
+    }
+    this._super();
+  },
+  disable: function() {
+    this.input.disabled = true;
+    if(this.selectize) {
+      this.selectize[0].selectize.lock();
+    }
+    this._super();
+  },
+  destroy: function() {
+    if(this.label && this.label.parentNode) this.label.parentNode.removeChild(this.label);
+    if(this.description && this.description.parentNode) this.description.parentNode.removeChild(this.description);
+    if(this.input && this.input.parentNode) this.input.parentNode.removeChild(this.input);
+    if(this.selectize) {
+      this.selectize[0].selectize.destroy();
+      this.selectize = null;
+    }
+    this._super();
+  }
+});


### PR DESCRIPTION
PR by myself @philostler, @radioisradio and @JulianKigwana to add Selectize support to json-editor.

Before:
![json_editor_example](https://cloud.githubusercontent.com/assets/244198/7707393/6f566968-fe47-11e4-915c-a88768e389c9.png)
After:
![json_editor_example 2](https://cloud.githubusercontent.com/assets/244198/7707400/76cce14a-fe47-11e4-8377-c7dfe3aea7dd.png)
And a new Selectize example:
![json_editor_selectize_integration_example](https://cloud.githubusercontent.com/assets/244198/7707406/818bb17e-fe47-11e4-94fc-67611bc21b38.png)

**Notes:**
We've made every effort to remain backwards compatible with how json-editor works as of now. So, as before, Select2 will be used if it is present (we didn't want to break this default behaviour).

If you want Selectize turned on then the following snippet does that for you:
```js
JSONEditor.plugins.selectize.enable = true;
```

I think, given that you can now use Select2 and Selectize, there's a case for seperating the editors out which is what we began thinking about. You'll see that in that `array` editor for Selectize is in it's own module. 

Ultimately though that would be a larger change (and a major/minor revision increment) that would probably make selecting between Select2 and Selectize nicer as well. One idea would be to pass in the prefer enhanced UI in to the editor options. e.g.
```js
this.editor = new JSONEditor(element, {
    enhanced_ui: 'selectize', // or 'select2' or anything else for 'default'
    schema: schema
});
```

We didn't want to undertake that as well, so this PR only includes Selectize support and no new ideas on how to better select your enhanced UI options

Enjoy!