### PR TITLE
Generate sourcemap back to the original pre-concatenated files.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,66 +2,71 @@
 
 module.exports = function(grunt) {
   grunt.initConfig({
-    concat: {
-      dist: {
-        src: [
-          // License & version info, start the containing closure
-          'src/intro.js',
-          
-          // Simple inheritance
-          'src/class.js',
-          // IE9 polyfills
-          'src/ie9.js',
-          // Utils like extend, each, and trigger
-          'src/utilities.js',
-          
-          // The main JSONEditor class
-          'src/core.js',
+    concat_sourcemap: {
+      options: {
+        sourcesContent: true
+      },
+      target: {
+        files: { 
+          'dist/jsoneditor.js': [
+            
+            // License & version info, start the containing closure
+            'src/intro.js',
+            
+            // Simple inheritance
+            'src/class.js',
+            // IE9 polyfills
+            'src/ie9.js',
+            // Utils like extend, each, and trigger
+            'src/utilities.js',
+            
+            // The main JSONEditor class
+            'src/core.js',
 
-          // JSON Schema validator
-          'src/validator.js',
-          
-          // All the editors
-          'src/editor.js',
-          'src/editors/null.js',
-          'src/editors/string.js',
-          'src/editors/number.js',
-          'src/editors/integer.js',
-          'src/editors/object.js',
-          'src/editors/array.js',
-          'src/editors/table.js',
-          'src/editors/multiple.js',
-          'src/editors/enum.js',
-          'src/editors/select.js',
-          'src/editors/multiselect.js',
-          'src/editors/base64.js',
-          'src/editors/upload.js',
-          'src/editors/checkbox.js',
+            // JSON Schema validator
+            'src/validator.js',
+            
+            // All the editors
+            'src/editor.js',
+            'src/editors/null.js',
+            'src/editors/string.js',
+            'src/editors/number.js',
+            'src/editors/integer.js',
+            'src/editors/object.js',
+            'src/editors/array.js',
+            'src/editors/table.js',
+            'src/editors/multiple.js',
+            'src/editors/enum.js',
+            'src/editors/select.js',
+            'src/editors/multiselect.js',
+            'src/editors/base64.js',
+            'src/editors/upload.js',
+            'src/editors/checkbox.js',
 
-          // All the themes and iconlibs
-          'src/theme.js',
-          'src/themes/*.js',
-          'src/iconlib.js',
-          'src/iconlibs/*.js',
+            // All the themes and iconlibs
+            'src/theme.js',
+            'src/themes/*.js',
+            'src/iconlib.js',
+            'src/iconlibs/*.js',
 
-          // The JS templating engines
-          'src/templates/*.js',
+            // The JS templating engines
+            'src/templates/*.js',
 
-          // Set the defaults
-          'src/defaults.js',
-          
-          // Wrapper for $.fn style initialization
-          'src/jquery.js',
-          
-          // End the closure
-          'src/outro.js'
-        ],
-        dest: 'dist/jsoneditor.js'
+            // Set the defaults
+            'src/defaults.js',
+            
+            // Wrapper for $.fn style initialization
+            'src/jquery.js',
+            
+            // End the closure
+            'src/outro.js'
+          ],
+        }
       }
     },
     uglify: {
       dist: {
-        src: '<%= concat.dist.dest %>',
+        src: 'dist/jsoneditor.js',
         dest: 'dist/jsoneditor.min.js'
       },
       options: {
@@ -127,12 +132,12 @@ module.exports = function(grunt) {
   });
 
   // These plugins provide necessary tasks.
-  grunt.loadNpmTasks('grunt-contrib-concat');
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-contrib-jshint');
+  grunt.loadNpmTasks('grunt-concat-sourcemap');
 
   // Default task.
-  grunt.registerTask('default', ['jshint:beforeconcat','concat','jshint:afterconcat','uglify']);
+  grunt.registerTask('default', ['jshint:beforeconcat','concat_sourcemap','jshint:afterconcat','uglify']);
 
 };

--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
     "node": ">= 0.8.0"
   },
   "devDependencies": {
-    "grunt-contrib-concat": "~0.3.0",
-    "grunt-contrib-uglify": "~0.2.0",
-    "grunt-contrib-watch": "~0.5.3",
+    "grunt": "~0.4.2",
+    "grunt-concat-sourcemap": "^0.4.3",
     "grunt-contrib-jshint": "^0.10.0",
-    "grunt": "~0.4.2"
+    "grunt-contrib-uglify": "~0.2.0",
+    "grunt-contrib-watch": "~0.5.3"
   },
   "scripts": {
     "build": "npm install && grunt",


### PR DESCRIPTION
Makes debugging a bit friendlier: 
![screenshot 2015-06-04 14 21 10](https://cloud.githubusercontent.com/assets/678344/7976846/f9d93fa0-0ac4-11e5-8785-df48538638b3.png)

The way I've done it you don't get sourcemaps for the min version.