### PR TITLE
Allow static items for enumSource

### DIFF
--- a/README.md
+++ b/README.md
@@ -951,6 +951,29 @@ Here's a more complex example (this uses the Swig template engine syntax to show
 }
 ```
 
+You can also specify a list of static items with a slightly different syntax:
+
+```js+jinja
+{
+  "enumSource": [{
+      // A watched field source
+      "source": [
+        {
+          "value": 1,
+          "title": "One"
+        },
+        {
+          "value": 2,
+          "title": "Two"
+        }
+      ],
+      "title": "{{item.title}}",
+      "value": "{{item.value}}"
+    }]
+  ]
+}
+```
+
 The colors examples used an array of strings directly.  Using the verbose form, you can 
 also make it work with an array of objects.  Here's an example:
 

--- a/src/editors/select.js
+++ b/src/editors/select.js
@@ -211,9 +211,15 @@ JSONEditor.defaults.editors.select = JSONEditor.AbstractEditor.extend({
           select_options = select_options.concat(this.enumSource[i]);
           select_titles = select_titles.concat(this.enumSource[i]);
         }
-        // A watched field
-        else if(vars[this.enumSource[i].source]) {
-          var items = vars[this.enumSource[i].source];
+        else {
+          var items = [];
+          // Static list of items
+          if(Array.isArray(this.enumSource[i].source)) {
+            items = this.enumSource[i].source;
+          // A watched field
+          } else {
+            items = vars[this.enumSource[i].source];
+          }
           
           // Only use a predefined part of the array
           if(this.enumSource[i].slice) {


### PR DESCRIPTION
The "source" of "enumSource" may now be an array of static items
which may be processed similarly to values from watched fields.