### PR TITLE
Fix disabling additional properties per object

### DIFF
--- a/src/editors/object.js
+++ b/src/editors/object.js
@@ -661,7 +661,10 @@ JSONEditor.defaults.editors.object = JSONEditor.AbstractEditor.extend({
     this._super(editor);
   },
   canHaveAdditionalProperties: function() {
-    return (this.schema.additionalProperties === true) || !this.jsoneditor.options.no_additional_properties;
+    if (typeof this.schema.additionalProperties === "boolean") {
+      return this.schema.additionalProperties;
+    }
+    return !this.jsoneditor.options.no_additional_properties;
   },
   destroy: function() {
     $each(this.cached_editors, function(i,el) {


### PR DESCRIPTION
This makes sure that per object "additionalProperties" are correctly
evaluated and preferred over the global "no_additional_properties".

Fixes #438