### PR TITLE
Add class to property selector.

### DIFF
--- a/src/editors/object.js
+++ b/src/editors/object.js
@@ -327,6 +327,7 @@ JSONEditor.defaults.editors.object = JSONEditor.AbstractEditor.extend({
       this.addproperty_list.style.overflowY = 'auto';
       this.addproperty_list.style.overflowX = 'hidden';
       this.addproperty_list.style.paddingLeft = '5px';
+      this.addproperty_list.setAttribute('class', 'property-selector');
       this.addproperty_add = this.getButton('add','add','add');
       this.addproperty_input = this.theme.getFormInputField('text');
       this.addproperty_input.setAttribute('placeholder','Property name...');


### PR DESCRIPTION
The properties `<div>` has no class, no id, and a hardcoded `maxheight` of 160px. It's pretty hard to get to using CSS without a class.
