### PR TITLE
Add partial form support

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -17,12 +17,13 @@ JSONEditor.prototype = {
     if(!theme_class) throw "Unknown theme " + (this.options.theme || JSONEditor.defaults.theme);
     
     this.schema = this.options.schema;
+    this.root_schema = this.options.root_schema ? $walk(this.options.root_schema, this.schema) : this.schema;
     this.theme = new theme_class();
     this.template = this.options.template;
     this.refs = this.options.refs || {};
     this.uuid = 0;
     this.__data = {};
-    
+
     var icon_class = JSONEditor.defaults.iconlibs[this.options.iconlib || JSONEditor.defaults.iconlib];
     if(icon_class) this.iconlib = new icon_class();
 
@@ -37,10 +38,10 @@ JSONEditor.prototype = {
       self.validator = new JSONEditor.Validator(self);
       
       // Create the root editor
-      var editor_class = self.getEditorClass(self.schema);
+      var editor_class = self.getEditorClass(self.root_schema);
       self.root = self.createEditor(editor_class, {
         jsoneditor: self,
-        schema: self.schema,
+        schema: self.root_schema,
         required: true,
         container: self.root_container
       });

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -94,3 +94,17 @@ var $triggerc = function(el,event) {
 
   el.dispatchEvent(e);
 };
+
+
+var $walk = function(path,obj) {
+  path = path.split('.');
+  for (var i = 0; i < path.length; ++i) {
+    if (obj[path[i]]) {
+      obj = obj[path[i]];
+    }
+    else {
+      return null;
+    }
+  }
+  return obj;
+}

--- a/src/validator.js
+++ b/src/validator.js
@@ -1,7 +1,7 @@
 JSONEditor.Validator = Class.extend({
   init: function(jsoneditor,schema) {
     this.jsoneditor = jsoneditor;
-    this.schema = schema || this.jsoneditor.schema;
+    this.schema = schema || this.jsoneditor.root_schema;
     this.options = {};
     this.translate = this.jsoneditor.translate || JSONEditor.defaults.translate;
   },


### PR DESCRIPTION
This adds a new option `root_schema` that is a dot-notated string that describes a sub-section of a schema to use when generating the form.

This is useful when you have a schema with definitions and other shared items, but different parts of the schema need to be in different forms (for example in different tabs like #331). This makes that possible.

Usage example:

```js
var editor = new JSONEditor(element, {
    schema: {
        "$schema": "http://json-schema.org/schema#",
        "definitions": { /* ... */ },
        "type": "object",
        "properties": {
            "containers": {
                "type": "array",
                "items": {
                    "type": "object",
                    "properties": {               
                        "id": { "type": "string" },
                        "base": { "$ref": "#/definitions/containerInfo" },
                        "variants": { "$ref": "#/definitions/containerInfo" }
                    }
                }
            }
        }
    },
    root_schema: "properties.containers.items.properties.base"
});
```

This will generate a form for just the "base" object, which in my case is necessary. I can then put the variant form on a separate tab, and keep all the other values ("id", etc) out of the form completely.