### PR TITLE
Empty choice for non required properties in select drop downs

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -368,6 +368,12 @@ JSONEditor.AbstractEditor = Class.extend({
   isEnabled: function() {
     return !this.disabled;
   },
+  isRequired: function() {
+    if(typeof this.schema.required === "boolean") return this.schema.required;
+    else if(this.parent && this.parent.schema && Array.isArray(this.parent.schema.required)) return this.parent.schema.required.indexOf(this.key) > -1;
+    else if(this.jsoneditor.options.required_by_default) return true;
+    else return false;
+  },  
   getDisplayText: function(arr) {
     var disp = [];
     var used = {};

--- a/src/editors/select.js
+++ b/src/editors/select.js
@@ -68,12 +68,26 @@ JSONEditor.defaults.editors.select = JSONEditor.AbstractEditor.extend({
         self.enum_display[i] = ""+(display[i] || option);
         self.enum_values[i] = self.typecast(option);
       });
+
+      if(!this.schema.required){
+        self.enum_display.unshift(' ');
+        self.enum_options.unshift('undefined');
+        self.enum_values.unshift(undefined)
+      }
+            
     }
     // Boolean
     else if(this.schema.type === "boolean") {
       self.enum_display = this.schema.options && this.schema.options.enum_titles || ['true','false'];
       self.enum_options = ['1',''];
       self.enum_values = [true,false];
+      
+      if(!this.schema.required){
+        self.enum_display.unshift(' ');
+        self.enum_options.unshift('undefined');
+        self.enum_values.unshift(undefined)
+      }
+    
     }
     // Dynamic Enum
     else if(this.schema.enumSource) {

--- a/src/editors/select.js
+++ b/src/editors/select.js
@@ -69,7 +69,7 @@ JSONEditor.defaults.editors.select = JSONEditor.AbstractEditor.extend({
         self.enum_values[i] = self.typecast(option);
       });
 
-      if(!this.schema.required){
+      if(!this.isRequired()){
         self.enum_display.unshift(' ');
         self.enum_options.unshift('undefined');
         self.enum_values.unshift(undefined);
@@ -82,7 +82,7 @@ JSONEditor.defaults.editors.select = JSONEditor.AbstractEditor.extend({
       self.enum_options = ['1',''];
       self.enum_values = [true,false];
       
-      if(!this.schema.required){
+      if(!this.isRequired()){
         self.enum_display.unshift(' ');
         self.enum_options.unshift('undefined');
         self.enum_values.unshift(undefined);

--- a/src/editors/select.js
+++ b/src/editors/select.js
@@ -72,7 +72,7 @@ JSONEditor.defaults.editors.select = JSONEditor.AbstractEditor.extend({
       if(!this.schema.required){
         self.enum_display.unshift(' ');
         self.enum_options.unshift('undefined');
-        self.enum_values.unshift(undefined)
+        self.enum_values.unshift(undefined);
       }
             
     }
@@ -85,7 +85,7 @@ JSONEditor.defaults.editors.select = JSONEditor.AbstractEditor.extend({
       if(!this.schema.required){
         self.enum_display.unshift(' ');
         self.enum_options.unshift('undefined');
-        self.enum_values.unshift(undefined)
+        self.enum_values.unshift(undefined);
       }
     
     }


### PR DESCRIPTION
This is a proposal fix for https://github.com/jdorn/json-editor/issues/400

If an enumerated property is not marked as required then the drop down will display an additional empty choice:

![dropdown](https://cloud.githubusercontent.com/assets/2689930/8596289/6ebf4aea-264e-11e5-84cf-f513110bb64b.png)

If the empty choice is selected than the property won't be defined in the resulting JSON.
