### PR TITLE
Select editors values are not being casted properly

### DIFF
--- a/src/editors/select.js
+++ b/src/editors/select.js
@@ -50,7 +50,7 @@ JSONEditor.defaults.editors.select = JSONEditor.AbstractEditor.extend({
     }
   },
   getValue: function() {
-    return this.value;
+    return this.typecast(this.value);
   },
   preBuild: function() {
     var self = this;
@@ -292,7 +292,7 @@ JSONEditor.defaults.editors.select = JSONEditor.AbstractEditor.extend({
       // Otherwise, set the value to the first select option
       else {
         this.input.value = select_options[0];
-        this.value = select_options[0] || "";  
+        this.value = this.typecast(select_options[0] || "");  
         if(this.parent) this.parent.onChildEditorChange(this);
         else this.jsoneditor.onChange();
         this.jsoneditor.notifyWatchers(this.path);


### PR DESCRIPTION
The values for the select editors are not always being casted.
The approach for solving this has been to cast the value returned by the getValue() function instead of casting every single value passed to the this.value assignments.