### PR TITLE
Check that regex matching template vars is not null

### DIFF
--- a/src/templates/default.js
+++ b/src/templates/default.js
@@ -2,7 +2,7 @@ JSONEditor.defaults.templates["default"] = function() {
   return {
     compile: function(template) {
       var matches = template.match(/{{\s*([a-zA-Z0-9\-_\.]+)\s*}}/g);
-      var l = matches.length;
+      var l = matches && matches.length;
 
       // Shortcut if the template contains no variables
       if(!l) return function() { return template; };


### PR DESCRIPTION
Will otherwise get errors when no vars are present in the template.