### PR TITLE
Avoid displaying string "undefined" when value is `undefined`

### DIFF
--- a/src/editors/string.js
+++ b/src/editors/string.js
@@ -16,7 +16,7 @@ JSONEditor.defaults.editors.string = JSONEditor.AbstractEditor.extend({
       return;
     }
     
-    if(value === null) value = "";
+    if(value === null || typeof value === 'undefined') value = "";
     else if(typeof value === "object") value = JSON.stringify(value);
     else if(typeof value !== "string") value = ""+value;
     


### PR DESCRIPTION
Am getting default string values showing as "undefined"