### PR TITLE
Checbox save selection fix

### DIFF
--- a/src/editors/checkbox.js
+++ b/src/editors/checkbox.js
@@ -2,7 +2,7 @@ JSONEditor.defaults.editors.checkbox = JSONEditor.AbstractEditor.extend({
   setValue: function(value,initial) {
     this.value = !!value;
     this.input.checked = this.value;
-    this.onChange();
+    this.onChange(true);
   },
   register: function() {
     this._super();


### PR DESCRIPTION
Fix the problem that the selection of checkboxes not saved in the output JSON (the json you get by the "editor.getValue()" function)
