### PR TITLE
Allow spaces in template variables

### DIFF
--- a/src/templates/default.js
+++ b/src/templates/default.js
@@ -1,7 +1,7 @@
 JSONEditor.defaults.templates["default"] = function() {
   return {
     compile: function(template) {
-      var matches = template.match(/{{\s*([a-zA-Z0-9\-_\.]+)\s*}}/g);
+      var matches = template.match(/{{\s*([a-zA-Z0-9\-_ \.]+)\s*}}/g);
       var l = matches.length;
 
       // Shortcut if the template contains no variables
@@ -11,7 +11,7 @@ JSONEditor.defaults.templates["default"] = function() {
       // This drastically speeds up template execution
       var replacements = [];
       var get_replacement = function(i) {
-        var p = matches[i].replace(/[{}\s]+/g,'').split('.');
+        var p = matches[i].replace(/[{}]+/g,'').trim().split('.');
         var n = p.length;
         var func;
         


### PR DESCRIPTION
This changeset adds support for spaces in template variable names, which worked up until the 0.7.19 release. An example schema that uses variables names with spaces is [here](http://jeremydorn.com/json-editor/?schema=N4IgJgpgzgxgTgSwA4BcEHsB2IBcIQA0IaKANhLvkUqQK5wCGpA+ieZYeBAGYKYJosUXKAAKEOFCwiQAW1qk0NCjhRxaEIpFiJUGbHgCCAAiQSp2ImxUhxk6UTgQAjrQROwuANohmpdDBMAJKeRABi7lAoxpgMshREADIMUTFxFAC61HSMLNaUdhbCWjx8AvrCOMAAvlYAnmaU6ABGAFYQMCicSHDoZnBo0DLJqbHxMghQAMoQDHAwABYMzew43ExQmiA9fRIodQDycJBwuACM9Y14UYiYAOacvBCkYAAqDTYoEAAeXUTc6DgsgYXTwX1+IFqIAikmiYxUoEmMzmi2Wq3WpE21F6/X2RxOuAADJcbDc+A9/ghnm8PpRwX8QACgSC6T8ulC/AFgp4qtsQV84AYQAA9LwMAC03EM4rChPFAE4MsAABzVcViyXS2UKpUAFjVGqlMrliuA+vVEqN2tN5sNWpNSrOACZqgASTj7K4gMn3Th9QSYSqgBYIMCQAxqDTVaNQgBqEBDMFWoHkimQq0jW208GQAcoJnjifYVgEqxAhYQSYSICcrncEB5Pk5gVIIRAWW2OSYrFLNgrVeKXF4/ADQahnpsLXanW6OL2VKDIAAsgwANYIkBI2bzJYrFQYrHbOcDQ7HCREkmUH0UxlUl7vL30x6A4Gg4hsyFEZvcmRIfkSIVRUte0dRVA1gONUDbQg609XAzVIJteCrQdYBnTdD1aWuNRyT9PQhBkEMwwgCN1AgaMiAAEUQAA3c9eQAdxBRYZBQOY7ggN9CmkKESNoWQpnQegYBULxQCkYTPnYzjOBopgNEoYBgAECBZAAOm/VswGjD1e0U5SvnUmFRnSaNjCUlT1JGOFTOqSEOwnK8cN9SlqQfGwnG4CQSJE2ddhPfF6IAZihJd0EgUgJmmbdUT3XADy2HZcVPAkcAuYgsO9Zybyee9Mqff4XxZMEPyhABNbcouRHc0X3DZEuPPEz1OHAnUvbDbhyu8aUfD9CuZN8nxjKFXVgBZVIYSgFhQFAkBwAB6ebWgscUxomtTATueawEYbgUHFQldXmtbgQAYkwr0pw6BkkvnIZeW4gxEUMxdXU8yhTu20oRwqebHs/DKvTmRg6gB/tk03F6ZDengPq+4dyiEebwYocdMuBhhQZjIAAAA==&value=N4IgCgpgTgzg9gOxALgNoF0A0IBqEAWAlgMYA2EKGAvkAA==&theme=bootstrap2&iconlib=fontawesome4&object_layout=normal&show_errors=interaction). Notice that when trying to add a vehicle item, there is a javascript console error.