### PR TITLE
Add support for passing a theme instance as editor option

### DIFF
--- a/examples/theming.html
+++ b/examples/theming.html
@@ -14,7 +14,7 @@
     <script>
     // Set the default CSS theme and icon library globally
     // The theme can be reused to generate custom UI elements
-    var theme = new JSONEditor.defaults.themes["foundation5"]()
+    var theme = new JSONEditor.defaults.themes["foundation5"]();
     JSONEditor.defaults.theme = theme;
     JSONEditor.defaults.iconlib = 'fontawesome4';
     </script>

--- a/examples/theming.html
+++ b/examples/theming.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Standalone theme JSON Editor Example</title>
+
+    <!-- Foundation CSS framework (Bootstrap and jQueryUI also supported) -->
+    <link rel='stylesheet' href='//cdn.jsdelivr.net/foundation/5.0.2/css/foundation.min.css'>
+    <!-- Font Awesome icons (Bootstrap, Foundation, and jQueryUI also supported) -->
+    <link rel='stylesheet' href='//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.0.3/css/font-awesome.css'>
+
+    <script src="../dist/jsoneditor.js"></script>
+
+    <script>
+    // Set the default CSS theme and icon library globally
+    // The theme can be reused to generate custom UI elements
+    var theme = new JSONEditor.defaults.themes["foundation5"]()
+    JSONEditor.defaults.theme = theme;
+    JSONEditor.defaults.iconlib = 'fontawesome4';
+    </script>
+  </head>
+  <body>
+    <div class='row'>
+      <div class='medium-12 columns'>
+        <h1>CSS Integration JSON Editor Example</h1>
+      </div>
+    </div>
+    <div class='row'>
+      <div class='medium-6 columns'>
+        <p>JSON Editor supports these popular CSS frameworks:</p>
+        <ul>
+          <li>Bootstrap 2</li>
+          <li>Bootstrap 3</li>
+          <li>Foundation 3</li>
+          <li>Foundation 4</li>
+          <li>Foundation 5 (shown here)</li>
+          <li>jQuery UI</li>
+        </ul>
+      </div>
+      <div class='medium-6 columns'>
+        <p>JSON Editor supports these popular icon libraries:</p>
+        <ul>
+          <li>Bootstrap 2 Glyphicons</li>
+          <li>Bootstrap 3 Glyphicons</li>
+          <li>Foundicons 2</li>
+          <li>Foundicons 3</li>
+          <li>jQueryUI</li>
+          <li>Font Awesome 3</li>
+          <li>Font Awesome 4 (shown here)</li>
+        </ul>
+      </div>
+    </div>
+    <div class='row'>
+      <div class='medium-12-columns'>
+        <button id='submit' class='tiny'>Submit (console.log)</button>
+        <button id='restore' class='secondary tiny'>Restore to Default</button>
+        <span id='valid_indicator' class='label'></span>
+      </div>
+    </div>
+    <div class='row'>
+      <div id='editor_holder' class='medium-12 columns'></div>
+    </div>
+
+    <script>
+      // This is the starting value for the editor
+      // We will use this to seed the initial editor
+      // and to provide a "Restore to Default" button.
+      var starting_value = {
+        name: "John Smith",
+        age: 35,
+        gender: "male",
+        location: {
+          city: "San Francisco",
+          state: "California"
+        },
+        pets: [
+          {
+            name: "Spot",
+            type: "dog",
+            fixed: true
+          },
+          {
+            name: "Whiskers",
+            type: "cat",
+            fixed: false
+          }
+        ]
+      };
+
+      // Initialize the editor
+      var editor = new JSONEditor(document.getElementById('editor_holder'),{
+        // Enable fetching schemas via ajax
+        ajax: true,
+        // We could have set the theme here instead of globally
+        //theme: theme,
+
+        // The schema for the editor
+        schema: {
+          $ref: "person.json",
+          format: "grid"
+        },
+
+        // Seed the form with a starting value
+        startval: starting_value
+      });
+
+      // Hook up the submit button to log to the console
+      document.getElementById('submit').addEventListener('click',function() {
+        // Get the value from the editor
+        console.log(editor.getValue());
+      });
+
+      // Hook up the Restore to Default button
+      document.getElementById('restore').addEventListener('click',function() {
+        editor.setValue(starting_value);
+      });
+
+      // Hook up the validation indicator to update its
+      // status whenever the editor changes
+      editor.on('change',function() {
+        // Get an array of errors from the validator
+        var errors = editor.validate();
+
+        var indicator = document.getElementById('valid_indicator');
+
+        // Not valid
+        if(errors.length) {
+          indicator.className = 'label alert';
+          indicator.textContent = 'not valid';
+        }
+        // Valid
+        else {
+          indicator.className = 'label success';
+          indicator.textContent = 'valid';
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/src/core.js
+++ b/src/core.js
@@ -10,32 +10,44 @@ var JSONEditor = function(element,options) {
 JSONEditor.prototype = {
   init: function() {
     var self = this;
-    
-    this.ready = false;
+    var theme;
 
-    var theme_class = JSONEditor.defaults.themes[this.options.theme || JSONEditor.defaults.theme];
-    if(!theme_class) throw "Unknown theme " + (this.options.theme || JSONEditor.defaults.theme);
-    
+    this.ready = false;
     this.schema = this.options.schema;
-    this.theme = new theme_class();
+
+    if (this.options.theme instanceof JSONEditor.AbstractTheme) {
+      theme = this.options.theme;
+    }
+
+    if (!theme && JSONEditor.defaults.theme instanceof JSONEditor.AbstractTheme) {
+      theme = JSONEditor.defaults.theme;
+    }
+
+    if (!theme) {
+      var theme_class = JSONEditor.defaults.themes[this.options.theme || JSONEditor.defaults.theme];
+      if(!theme_class) throw "Unknown theme " + (this.options.theme || JSONEditor.defaults.theme);
+      theme = new theme_class();
+    }
+
+    this.theme = theme;
     this.template = this.options.template;
     this.refs = this.options.refs || {};
     this.uuid = 0;
     this.__data = {};
-    
+
     var icon_class = JSONEditor.defaults.iconlibs[this.options.iconlib || JSONEditor.defaults.iconlib];
     if(icon_class) this.iconlib = new icon_class();
 
     this.root_container = this.theme.getContainer();
     this.element.appendChild(this.root_container);
-    
+
     this.translate = this.options.translate || JSONEditor.defaults.translate;
 
     // Fetch all external refs via ajax
     this._loadExternalRefs(this.schema, function() {
       self._getDefinitions(self.schema);
       self.validator = new JSONEditor.Validator(self);
-      
+
       // Create the root editor
       var editor_class = self.getEditorClass(self.schema);
       self.root = self.createEditor(editor_class, {
@@ -44,7 +56,7 @@ JSONEditor.prototype = {
         required: true,
         container: self.root_container
       });
-      
+
       self.root.preBuild();
       self.root.build();
       self.root.postBuild();
@@ -79,7 +91,7 @@ JSONEditor.prototype = {
   },
   validate: function(value) {
     if(!this.ready) throw "JSON Editor not ready yet.  Listen for 'ready' event before validating";
-    
+
     // Custom value
     if(arguments.length === 1) {
       return this.validator.validate(value);
@@ -92,7 +104,7 @@ JSONEditor.prototype = {
   destroy: function() {
     if(this.destroyed) return;
     if(!this.ready) return;
-    
+
     this.schema = null;
     this.options = null;
     this.root.destroy();
@@ -106,14 +118,14 @@ JSONEditor.prototype = {
     this.__data = null;
     this.ready = false;
     this.element.innerHTML = '';
-    
+
     this.destroyed = true;
   },
   on: function(event, callback) {
     this.callbacks = this.callbacks || {};
     this.callbacks[event] = this.callbacks[event] || [];
     this.callbacks[event].push(callback);
-    
+
     return this;
   },
   off: function(event, callback) {
@@ -137,7 +149,7 @@ JSONEditor.prototype = {
     else {
       this.callbacks = {};
     }
-    
+
     return this;
   },
   trigger: function(event) {
@@ -146,7 +158,7 @@ JSONEditor.prototype = {
         this.callbacks[event][i]();
       }
     }
-    
+
     return this;
   },
   setOption: function(option, value) {
@@ -158,7 +170,7 @@ JSONEditor.prototype = {
     else {
       throw "Option "+option+" must be set during instantiation and cannot be changed later";
     }
-    
+
     return this;
   },
   getEditorClass: function(schema) {
@@ -187,30 +199,30 @@ JSONEditor.prototype = {
   },
   onChange: function() {
     if(!this.ready) return;
-    
+
     if(this.firing_change) return;
     this.firing_change = true;
-    
+
     var self = this;
-    
+
     window.requestAnimationFrame(function() {
       self.firing_change = false;
       if(!self.ready) return;
 
       // Validate and cache results
       self.validation_results = self.validator.validate(self.root.getValue());
-      
+
       if(self.options.show_errors !== "never") {
         self.root.showValidationErrors(self.validation_results);
       }
       else {
         self.root.showValidationErrors([]);
       }
-      
+
       // Fire change event
       self.trigger('change');
     });
-    
+
     return this;
   },
   compileTemplate: function(template, name) {
@@ -253,7 +265,7 @@ JSONEditor.prototype = {
     else {
       // No data stored
       if(!el.hasAttribute('data-jsoneditor-'+key)) return null;
-      
+
       return this.__data[el.getAttribute('data-jsoneditor-'+key)];
     }
   },
@@ -275,7 +287,7 @@ JSONEditor.prototype = {
     this.watchlist = this.watchlist || {};
     this.watchlist[path] = this.watchlist[path] || [];
     this.watchlist[path].push(callback);
-    
+
     return this;
   },
   unwatch: function(path,callback) {
@@ -285,7 +297,7 @@ JSONEditor.prototype = {
       this.watchlist[path] = null;
       return this;
     }
-    
+
     var newlist = [];
     for(var i=0; i<this.watchlist[path].length; i++) {
       if(this.watchlist[path][i] === callback) continue;
@@ -330,11 +342,11 @@ JSONEditor.prototype = {
         }
       }
     };
-    
+
     if(schema.$ref && typeof schema.$ref !== "object" && schema.$ref.substr(0,1) !== "#" && !this.refs[schema.$ref]) {
       refs[schema.$ref] = true;
     }
-    
+
     for(var i in schema) {
       if(!schema.hasOwnProperty(i)) continue;
       if(schema[i] && typeof schema[i] === "object" && Array.isArray(schema[i])) {
@@ -348,25 +360,25 @@ JSONEditor.prototype = {
         merge_refs(this._getExternalRefs(schema[i]));
       }
     }
-    
+
     return refs;
   },
   _loadExternalRefs: function(schema, callback) {
     var self = this;
     var refs = this._getExternalRefs(schema);
-    
+
     var done = 0, waiting = 0, callback_fired = false;
-    
+
     $each(refs,function(url) {
       if(self.refs[url]) return;
       if(!self.options.ajax) throw "Must set ajax option to true to load external ref "+url;
       self.refs[url] = 'loading';
       waiting++;
 
-      var r = new XMLHttpRequest(); 
+      var r = new XMLHttpRequest();
       r.open("GET", url, true);
       r.onreadystatechange = function () {
-        if (r.readyState != 4) return; 
+        if (r.readyState != 4) return;
         // Request succeeded
         if(r.status === 200) {
           var response;
@@ -378,7 +390,7 @@ JSONEditor.prototype = {
             throw "Failed to parse external ref "+url;
           }
           if(!response || typeof response !== "object") throw "External ref does not contain a valid schema - "+url;
-          
+
           self.refs[url] = response;
           self._loadExternalRefs(response,function() {
             done++;
@@ -396,20 +408,20 @@ JSONEditor.prototype = {
       };
       r.send();
     });
-    
+
     if(!waiting) {
       callback();
     }
   },
   expandRefs: function(schema) {
     schema = $extend({},schema);
-    
+
     while (schema.$ref) {
       var ref = schema.$ref;
       delete schema.$ref;
-      
+
       if(!this.refs[ref]) ref = decodeURIComponent(ref);
-      
+
       schema = this.extendSchemas(schema,this.refs[ref]);
     }
     return schema;
@@ -469,7 +481,7 @@ JSONEditor.prototype = {
     if(schema.not) {
       schema.not = this.expandSchema(schema.not);
     }
-    
+
     // allOf schemas should be merged into the parent
     if(schema.allOf) {
       for(i=0; i<schema.allOf.length; i++) {
@@ -499,7 +511,7 @@ JSONEditor.prototype = {
         extended.oneOf[i] = this.extendSchemas(this.expandSchema(schema.oneOf[i]),tmp);
       }
     }
-    
+
     return this.expandRefs(extended);
   },
   extendSchemas: function(obj1, obj2) {


### PR DESCRIPTION
I am in the process of creating a CRUD client that will programatically assemble a UI by consuming a Heroku-style JSON hyperschema. Reusing json-editor themes seemed like an ideal option, since I don't want to rely on any bloated framework.

Still, it would be nice to separate themes from the editor itself, so we don't need to have code like this:

```
theme = JSONEditor.defaults.themes["foundation5"]();
JSONEditor.defaults.theme = theme;
```

Something shorter and not tied to JSONEditor would be better. We could even extract a separate lib.

Anyway, thanks for a great lib, I hope you have time to continue working on it, I'll try to help as much as possible.
