### PR TITLE
small null reference fix for https://github.com/jdorn/json-editor/issues/464

### DIFF
--- a/src/templates/default.js
+++ b/src/templates/default.js
@@ -2,7 +2,7 @@ JSONEditor.defaults.templates["default"] = function() {
   return {
     compile: function(template) {
       var matches = template.match(/{{\s*([a-zA-Z0-9\-_\.]+)\s*}}/g);
-      var l = matches.length;
+      var l = matches && matches.length;
 
       // Shortcut if the template contains no variables
       if(!l) return function() { return template; };


### PR DESCRIPTION
Hi,

This small fix avoids a null reference when checking `matches.length` as seen in issue https://github.com/jdorn/json-editor/issues/464

I just changed the single source file in this commit and didn't trying bumping the version or building a distribution or anything. Let me know if I need to change the commit in some way before you can pull it in.

Regards,
Robert