### PR TITLE
Add empty option for non-required dynamic select boxes

### DIFF
--- a/src/editors/select.js
+++ b/src/editors/select.js
@@ -299,6 +299,12 @@ JSONEditor.defaults.editors.select = JSONEditor.AbstractEditor.extend({
       }
       
       var prev_value = this.value;
+
+      // Add an empty option for non-required dynamic select boxes
+      if(!this.isRequired()){
+        select_options.unshift(undefined);
+        select_titles.unshift(' ');
+      }
       
       this.theme.setSelectOptions(this.input, select_options, select_titles);
       this.enum_options = select_options;


### PR DESCRIPTION
PR #461 added empty options to non-required select boxes, but it didn't do so for dynamic select boxes (those with watched fields). This commit adds that capability.
