### PR TITLE
Allow for required fields

### DIFF
--- a/src/editors/string.js
+++ b/src/editors/string.js
@@ -170,6 +170,10 @@ JSONEditor.defaults.editors.string = JSONEditor.AbstractEditor.extend({
       this.input_type = 'text';
       this.input = this.theme.getFormInputField(this.input_type);
     }
+
+    if (this.schema.required) {
+        this.input.setAttribute('required', true);
+    }
     
     // minLength, maxLength, and pattern
     if(typeof this.schema.maxLength !== "undefined") this.input.setAttribute('maxlength',this.schema.maxLength);


### PR DESCRIPTION
Unless there's another way to do this and I'm not seeing it, this seems like a basic feature and allows us to use html5 validation. I'm also interested in allowing for other attributes like pattern, but this is a start.

If this is good, you/we'll probably want to update the documentation so people know this exists.
