### PR TITLE
Add download attribute for link tag to transfer downloaded filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,21 @@ Simple text link
 }
 ```
 
+Text link with base64 encoded data in it
+```js+jinja
+{
+  "title": "Link for file download widh data in it",
+  "type": "string",
+  "links": [
+    {
+      "rel": "anchor name",
+      "href": "...here is base64 encoded data string with MIME...",
+      "download": "filename for download"
+    }
+  ]
+}
+```
+
 Show a video preview (using HTML5 video)
 ```js+jinja
 {

--- a/src/editor.js
+++ b/src/editor.js
@@ -175,6 +175,9 @@ JSONEditor.AbstractEditor = Class.extend({
     
     // Template to generate the link href
     var href = this.jsoneditor.compileTemplate(data.href,this.template_engine);
+
+    // Template to generate the link's download attribute
+    var download = this.jsoneditor.compileTemplate(data.download, this.template_engine);          
     
     // Image links
     if(type === 'image') {
@@ -224,6 +227,9 @@ JSONEditor.AbstractEditor = Class.extend({
         var url = href(vars);
         holder.setAttribute('href',url);
         holder.textContent = data.rel || url;
+
+        var downloadCompile = download(vars);
+        holder.setAttribute('download', downloadCompile);                      
       });
     }
     


### PR DESCRIPTION
This little update allows sending in link tag encoded file with ability to set this filename in new 'download' attribute for link tag. 
We've tried to use this modified version locally for our job and made decision that it will be useful for somebody else.
To describe new ability it needs to add 'download' attribute for link like:

```js+jinja
{
  "title": "Link to downloaded file with data in it",
  "type": "string",
  "links": [
    {
      "rel": "anchor name",
      "href": "...here is base64 encoded data string with MIME...",
      "download": "filename for download"
    }
  ]
}
```


Best regards.
Stan.