### PR TITLE
Implemented template support for 'rel' property on href's schema

### DIFF
--- a/dist/jsoneditor.js
+++ b/dist/jsoneditor.js
@@ -1553,7 +1553,8 @@ JSONEditor.AbstractEditor = Class.extend({
     
     // Template to generate the link href
     var href = this.jsoneditor.compileTemplate(data.href,this.template_engine);
-
+    var relTemplate = this.jsoneditor.compileTemplate(data.rel,this.template_engine);
+    
     // Template to generate the link's download attribute
     var download = null;
     if(data.download) download = data.download;
@@ -1574,8 +1575,9 @@ JSONEditor.AbstractEditor = Class.extend({
       // When a watched field changes, update the url  
       this.link_watchers.push(function(vars) {
         var url = href(vars);
+        var rel = relTemplate(vars);
         link.setAttribute('href',url);
-        link.setAttribute('title',data.rel || url);
+        link.setAttribute('title',rel || url);
         image.setAttribute('src',url);
       });
     }
@@ -1594,8 +1596,9 @@ JSONEditor.AbstractEditor = Class.extend({
       // When a watched field changes, update the url  
       this.link_watchers.push(function(vars) {
         var url = href(vars);
+        var rel = relTemplate(vars);
         link.setAttribute('href',url);
-        link.textContent = data.rel || url;
+        link.textContent = rel || url;
         media.setAttribute('src',url);
       });
     }
@@ -1608,8 +1611,9 @@ JSONEditor.AbstractEditor = Class.extend({
       // When a watched field changes, update the url
       this.link_watchers.push(function(vars) {
         var url = href(vars);
+        var rel = relTemplate(vars);
         holder.setAttribute('href',url);
-        holder.textContent = data.rel || url;
+        holder.textContent = rel || url;
       });
     }
 

--- a/src/editor.js
+++ b/src/editor.js
@@ -177,7 +177,8 @@ JSONEditor.AbstractEditor = Class.extend({
     
     // Template to generate the link href
     var href = this.jsoneditor.compileTemplate(data.href,this.template_engine);
-
+    var relTemplate = this.jsoneditor.compileTemplate(data.rel,this.template_engine);
+    
     // Template to generate the link's download attribute
     var download = null;
     if(data.download) download = data.download;
@@ -198,8 +199,9 @@ JSONEditor.AbstractEditor = Class.extend({
       // When a watched field changes, update the url  
       this.link_watchers.push(function(vars) {
         var url = href(vars);
+        var rel = relTemplate(vars);
         link.setAttribute('href',url);
-        link.setAttribute('title',data.rel || url);
+        link.setAttribute('title',rel || url);
         image.setAttribute('src',url);
       });
     }
@@ -218,8 +220,9 @@ JSONEditor.AbstractEditor = Class.extend({
       // When a watched field changes, update the url  
       this.link_watchers.push(function(vars) {
         var url = href(vars);
+        var rel = relTemplate(vars);
         link.setAttribute('href',url);
-        link.textContent = data.rel || url;
+        link.textContent = rel || url;
         media.setAttribute('src',url);
       });
     }
@@ -232,8 +235,9 @@ JSONEditor.AbstractEditor = Class.extend({
       // When a watched field changes, update the url
       this.link_watchers.push(function(vars) {
         var url = href(vars);
+        var rel = relTemplate(vars);
         holder.setAttribute('href',url);
-        holder.textContent = data.rel || url;
+        holder.textContent = rel || url;
       });
     }
 


### PR DESCRIPTION
If you're trying to use template feature with 'rel' property in "links" object (like on the json bellow), it does not work in the vanilla editor. 
Here the direct link to an example - http://goo.gl/Q135mw
```javascript
{  
   "type":"array",
   "title":"Dynamic urls",
   "items":{  
      "type":"object",
      "id":"related_im_prop_item",
      "properties":{  
         "name":{  
            "type":"string",
            "watch":{  
               "link_id":"related_im_prop_item.id",
               "link_title":"related_im_prop_item.name"
            },
            "links":[  
               {  
                  "href":"/test/path/{{link_id}}",
                  "rel":"{{link_title}}"
               }
            ]
         },
         "id":{  
            "type":"string"
         }
      }
   }
}
```
This change is aimed to fix the problem.