### PR TITLE
Add display_required_only

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,11 @@ Here are all the available options:
     <td>The CSS theme to use.  See the <strong>CSS Integration</strong> section below for more info.</td>
     <td><code>html</code></td>
   </tr>
+  <tr>
+    <td>display_required_only</td>
+    <td>If <code>true</code>, JSON Editor will only display required JSON properties by default.</td>
+    <td><code>false</code></td>
+  </tr>
   </tbody>
 </table>
 

--- a/src/editors/object.js
+++ b/src/editors/object.js
@@ -235,12 +235,21 @@ JSONEditor.defaults.editors.object = JSONEditor.AbstractEditor.extend({
     }
     // If the object should be rendered as a div
     else {
-      this.defaultProperties = this.schema.defaultProperties || Object.keys(this.schema.properties);
+      var includeKeys;
+      if(this.schema.defaultProperties) {
+        includeKeys = this.schema.defaultProperties;
+      }
+      else if(this.options.display_required_only && this.schema.required) {
+        includeKeys = this.schema.required;
+      }
+      else {
+       Object.keys(this.schema.properties);
+      }
 
       // Increase the grid width to account for padding
       self.maxwidth += 1;
 
-      $each(this.defaultProperties, function(i,key) {
+      $each(includeKeys, function(i,key) {
         self.addObjectProperty(key, true);
 
         if(self.editors[key]) {


### PR DESCRIPTION
I have a huge json schema with many options for data at many levels, but very few required parameters. Users should be required to enter only the stuff needed, but to be able to add properties when desired. I'm hoping to avoid confusing users when being presented with so many options.

Feedback always welcome.

P.S.
Thanks for making this code available!