### PR TITLE
Fixes object properties not showing up after deleting then re-adding array row

### DIFF
--- a/src/editors/array.js
+++ b/src/editors/array.js
@@ -612,7 +612,7 @@ JSONEditor.defaults.editors.array = JSONEditor.AbstractEditor.extend({
       var i = self.rows.length;
       if(self.row_cache[i]) {
         self.rows[i] = self.row_cache[i];
-        self.rows[i].setValue(self.rows[i].getDefault());
+        self.rows[i].setValue(self.rows[i].getDefault(), true);
         self.rows[i].container.style.display = '';
         if(self.rows[i].tab) self.rows[i].tab.style.display = '';
         self.rows[i].register();


### PR DESCRIPTION
This PR fixes a problem that, for schemas with object-typed array items, default/initial values are not set correctly when re-creating child items from the internal editor cache.

To reproduce this problem:

1. Navigate to [this demo page](http://jeremydorn.com/json-editor/?schema=N4IgLgngDgpiBcICGAnFSIgDQgJZhgFsBnBUSWBEAewCMArGAYzGxChWthTFxlPihi1QjAD6xMClwA7AOZlw0OIknT5IAL45hosanSZBSyogMY2+IgNAcuMHnxvJFFFSDWyFmn781AA=&value=NoXSAA==&theme=bootstrap2&iconlib=fontawesome4&object_layout=normal&show_errors=interaction&disable_edit_json&disable_properties).  The link includes encoded version of the following schema:

    ```json
    {
      "type": "array",
      "items": {
        "type": "object",
        "properties": {
          "some_string": {
            "type": "string"
          },
          "some_array": {
            "type": "array",
            "items": {
              "properties": {
                "a": {
                  "type": "string"
                }
              }
            }
          }
        }
      }
    }
    ```

2. Click on "+ item" to add an item
3. Click on "x item" to delete the item just created
4. Click on "+ item" again

I can imagine the user being quite confused, especially with "disable raw JSON editing" and "disable property buttons" options set.  The user will be left with no way of editing the content of the array item (in this case, properties of the object).

If we call `setValue(..., true)` (set `initial` to `true`), it fixes the problem.  The `object` editor removes a property when `initial` flag is not set and the property is not required.

```js
// src/editors/object.js around L819
// ...
      // Otherwise, remove value unless this is the initial set or it's required
      else if(!initial && !self.isRequired(editor)) {
        self.removeObjectProperty(i);
      }
// ...
```

Marking this data as `initial` makes sense, for two reasons:

* This provides for a consistent behavior with the first time editor objects are crated
* Editor objects restored from cache should be considered "initial", even if the object itself is cached, because to the user we are actually showing a new object with some initial, default values.
