### PR TITLE
Add a disable_type_switcher option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ Here are all the available options:
     <td><code>false</code></td>
   </tr>
   <tr>
+    <td>disable_type_switcher</td>
+    <td>If <code>true</code>, remove all type switcher from objects. It's recommended to use it with <code>disable_properties</code> option.</td>
+    <td><code>false</code></td>
+  </tr>
+  <tr>
     <td>form_name_root</td>
     <td>The first part of the `name` attribute of form inputs in the editor.  An full example name is `root[person][name]` where "root" is the form_name_root.</td>
     <td>root</td>

--- a/demo.html
+++ b/demo.html
@@ -94,6 +94,7 @@
                         <option value='disable_edit_json'>Disable "Edit JSON" buttons</option>
                         <option value='disable_collapse'>Disable collapse buttons</option>
                         <option value='disable_properties'>Disable properties buttons</option>
+                        <option value='disable_type_switcher'>Disable type switcher</option>
                         <option value='disable_array_add'>Disable array add buttons</option>
                         <option value='disable_array_reorder'>Disable array move buttons</option>
                         <option value='disable_array_delete'>Disable array delete buttons</option>

--- a/src/editors/multiple.js
+++ b/src/editors/multiple.js
@@ -171,6 +171,12 @@ JSONEditor.defaults.editors.multiple = JSONEditor.AbstractEditor.extend({
     this.container.appendChild(this.header);
 
     this.switcher = this.theme.getSwitcher(this.display_text);
+
+    // Disable the type switcher if specified
+    if(this.jsoneditor.options.disable_type_switcher){
+      this.switcher.style.display = "none";
+    }
+
     container.appendChild(this.switcher);
     this.switcher.addEventListener('change',function(e) {
       e.preventDefault();


### PR DESCRIPTION
This option disable the type switcher of the "multiple" editor. This prevent to change type of existing additional properties of a JSON use as start values but that was not defined in the shema. 

It's recommended to use it with disable_properties.