### PR TITLE
Add dependency system

### DIFF
--- a/src/editors/null.js
+++ b/src/editors/null.js
@@ -1,5 +1,8 @@
 JSONEditor.defaults.editors["null"] = JSONEditor.AbstractEditor.extend({
   getValue: function() {
+    if (!this.dependenciesFulfilled) {
+      return undefined;
+    }
     return null;
   },
   setValue: function() {

--- a/src/editors/number.js
+++ b/src/editors/number.js
@@ -6,6 +6,9 @@ JSONEditor.defaults.editors.number = JSONEditor.defaults.editors.string.extend({
     return 2;
   },
   getValue: function() {
+    if (!this.dependenciesFulfilled) {
+      return undefined;
+    }
     return this.value*1;
   }
 });

--- a/src/editors/object.js
+++ b/src/editors/object.js
@@ -694,6 +694,9 @@ JSONEditor.defaults.editors.object = JSONEditor.AbstractEditor.extend({
     this._super();
   },
   getValue: function() {
+    if (!this.dependenciesFulfilled) {
+      return undefined;
+    }
     var result = this._super();
     if(this.jsoneditor.options.remove_empty_properties || this.options.remove_empty_properties) {
       for(var i in result) {

--- a/src/editors/select.js
+++ b/src/editors/select.js
@@ -50,6 +50,9 @@ JSONEditor.defaults.editors.select = JSONEditor.AbstractEditor.extend({
     }
   },
   getValue: function() {
+    if (!this.dependenciesFulfilled) {
+      return undefined;
+    }
     return this.value;
   },
   preBuild: function() {

--- a/src/editors/selectize.js
+++ b/src/editors/selectize.js
@@ -54,6 +54,9 @@ JSONEditor.defaults.editors.selectize = JSONEditor.AbstractEditor.extend({
     }
   },
   getValue: function() {
+    if (!this.dependenciesFulfilled) {
+      return undefined;
+    }
     return this.value;
   },
   preBuild: function() {


### PR DESCRIPTION
This pull request allows you to make dependencies for fields so that if another field isn't in the value options, the field with the dependency will not be shown. This PR uses the internal field value watch system to notify fields of changes in their dependencies.

The dependency information is fetched from the `dependencies` field in the `options` field of the control. The `dependencies` field should be a map where the keys are the names of the fields depended on and the value is the expected value. The value may be an array to indicate multiple value possibilities.

Here's an example schema:
```json
{
  "title": "An object",
  "type": "object",
  "properties": {
    "fieldOne": {
      "title": "I should be changed to 'foo'",
      "type": "string",
      "default": "bar"
    },
    "depender": {
      "title": "I depend on fieldOne to be 'foo'",
      "type": "string",
      "options": {
        "dependencies": {
          "fieldOne": "foo"
        }
      }
    }
  }
}
```
And the output it produces (bootstrap 3 theme)
Before: ![Before preview image](http://i.imgur.com/4l2Jkp7.png)
After: ![After preview image](http://i.imgur.com/3W96WkX.png)