### PR TITLE
$ref and fetching tree node from external source

### DIFF
--- a/src/editors/select.js
+++ b/src/editors/select.js
@@ -145,6 +145,17 @@ JSONEditor.defaults.editors.select = JSONEditor.AbstractEditor.extend({
         if(this.enumSource[i].filter) {
           this.enumSource[i].filter = this.jsoneditor.compileTemplate(this.enumSource[i].filter, this.template_engine);
         }
+        // if the source yet is an object, then try to pull the $ref
+        if(this.enumSource[i].source && typeof this.enumSource[i].source == "object") {
+            var src = this.jsoneditor.expandRefs(this.enumSource[i].source);
+            this.enumSource[i].source = [];
+            var j;
+            var keys = Object.keys(src).sort();
+            for (j=0; j<keys.length; j++)
+            {
+                this.enumSource[i].source.push(src[j]);
+            }
+        }
       }
     }
     // Other, not supported

--- a/src/editors/selectize.js
+++ b/src/editors/selectize.js
@@ -135,6 +135,17 @@ JSONEditor.defaults.editors.selectize = JSONEditor.AbstractEditor.extend({
         if(this.enumSource[i].filter) {
           this.enumSource[i].filter = this.jsoneditor.compileTemplate(this.enumSource[i].filter, this.template_engine);
         }
+        // if the source yet is an object, then try to pull the $ref
+        if(this.enumSource[i].source && typeof this.enumSource[i].source == "object") {
+            var src = this.jsoneditor.expandRefs(this.enumSource[i].source);
+            this.enumSource[i].source = [];
+            var j;
+            var keys = Object.keys(src).sort();
+            for (j=0; j<keys.length; j++)
+            {
+                this.enumSource[i].source.push(src[j]);
+            }
+        }
       }
     }
     // Other, not supported

--- a/src/intro.js
+++ b/src/intro.js
@@ -1,8 +1,8 @@
-/*! JSON Editor v0.7.28 - JSON Schema -> HTML Editor
+/*! JSON Editor v0.7.29 - JSON Schema -> HTML Editor
  * By Jeremy Dorn - https://github.com/jdorn/json-editor/
  * Released under the MIT license
  *
- * Date: 2016-08-07
+ * Date: 2017-02-01
  */
 
 /**


### PR DESCRIPTION
Apparently, there were no way to fetch some **part** of external schema with `$ref`.  This pull request fixes this commit.

```json
{
    "$ref": "http://example.com/path/schema.json#/node_a/subnode_b"
}
```

Also, this commit allows `enumSource` to use `$ref`:

```json
{
    "type": "string",
    "enumSource": [{
        "source": {
            "$ref": "http://example.com/path/schema.json#/items"
        },
        "value": "{{item.id}}",
        "title": "Item <{{item.id}}>"
     }],
}
```