### PR TITLE
Fix for crash given schema {"enum":[null]}

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -348,7 +348,7 @@ JSONEditor.prototype = {
       if(!schema.hasOwnProperty(i)) continue;
       if(schema[i] && typeof schema[i] === "object" && Array.isArray(schema[i])) {
         for(var j=0; j<schema[i].length; j++) {
-          if(typeof schema[i][j]==="object") {
+          if(schema[i][j] && typeof schema[i][j]==="object") {
             merge_refs(this._getExternalRefs(schema[i][j]));
           }
         }


### PR DESCRIPTION
Go to http://jeremydorn.com/json-editor/ and put `{"enum":[null]}` as schema, then click update.
Observe the error in console.
This change fixes the code.
I didn't include the update to dist directory.