### PR TITLE
Include expanded schemas options to include refs

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -39,9 +39,9 @@ JSONEditor.AbstractEditor = Class.extend({
 
     this.original_schema = options.schema;
     this.schema = this.jsoneditor.expandSchema(this.original_schema);
-    
-    this.options = $extend({}, (this.options || {}), (options.schema.options || {}), options);
-    
+
+    this.options = $extend({}, (this.options || {}), (this.schema.options || {}), (options.schema.options || {}), options);
+
     if(!options.path && !this.schema.id) this.schema.id = 'root';
     this.path = options.path || 'root';
     this.formname = options.formname || this.path.replace(/\.([^.]+)/g,'[$1]');


### PR DESCRIPTION
This fixes an issue where `enum_titles` from `$refs` aren't considered.

Before:

![](https://i.imgur.com/zROBnQi.png)

After:

![](https://i.imgur.com/V5DbK5O.png)

Reproducing the issue on v0.7.28:

```js
var default_value = {
  "name": "Event name",
  "starterSegment": {
    "id": 7,
    "name": "User has registered email"
  }
};
var config_schema = {
  "$schema": "http://json-schema.org/draft-04/schema#",
  "id": "http://example.com/root.json",
  "definitions": {
    "segment": {
      "type": "object",
      "format": "select",
      "properties": {
        "id": { "type": "number", "minimum": 0 },
        "name": { "type": "string" }
      },
      "required": ["id", "name"],
      "enum": [{id: 1, name: "Hello kitty fans"},{id: 3, name: "User has not checked out recently"},{id: 7, name: "User has registered email"}],
      "options": {
        "enum_titles": ["Hello kitty fans", "User has not checked out recently", "User has registered email"]
      }
    }
  },
  "properties": {
    "name": {
      "default": "",
      "description": "An explanation about the purpose of this instance.",
      "id": "http://example.com/root.json/name",
      "propertyOrder": 50,
      "title": "The configuration's name. Only used for your benefit.",
      "type": "string"
    },
    "starterSegment": {
      "title": "Starter segment",
      "$ref": "#/definitions/segment",
      "propertyOrder": 350
    }
  },
  "required": ["name","starterSegment"],
  "type": "object"
};

// Initialize the editor
JSONEditor.defaults.theme = 'bootstrap3';
JSONEditor.defaults.iconlib = 'fontawesome4';
var editor = new JSONEditor(document.getElementById('jsoneditor-area'), {
  disable_edit_json: true,
  disable_properties: true,
  schema: config_schema,
  startval: default_value
});
```