### PR TITLE
if the propertyOrder undefined, then set a smart default value.

### DIFF
--- a/src/editors/object.js
+++ b/src/editors/object.js
@@ -638,6 +638,10 @@ JSONEditor.defaults.editors.object = JSONEditor.AbstractEditor.extend({
       }
 
       var schema = self.getPropertySchema(name);
+      if(typeof schema.propertyOrder !== 'number'){                  
+        // if the propertyOrder undefined, then set a smart default value.
+        schema.propertyOrder = Object.keys(self.editors).length + 1000;                                                                   
+      } 
 
 
       // Add the property


### PR DESCRIPTION
When the object properties count so many, and propertyOrder undefined, then render disordered editor.
so, set a smart default value, ensure order of editor.